### PR TITLE
Enable the ability to pass in a custom mocks file when we beginMocking

### DIFF
--- a/Pod/Classes/SuperMock.swift
+++ b/Pod/Classes/SuperMock.swift
@@ -27,8 +27,8 @@ public class SuperMock: NSObject {
         NSURLSessionConfiguration.defaultSessionConfiguration().protocolClasses = [SuperMockURLProtocol.self]
         NSURLSession.sharedSession().configuration.protocolClasses?.append(SuperMockURLProtocol)
         
+        SuperMockResponseHelper.mocksFileName  = mocksFile
         SuperMockResponseHelper.bundleForMocks = bundle
-        
     }
     
     class func beginRecording(bundle: NSBundle?, mocksFile: String? = "Mocks.plist", policy: SuperMockResponseHelper.RecordPolicy) {
@@ -37,9 +37,9 @@ public class SuperMock: NSObject {
         NSURLSessionConfiguration.defaultSessionConfiguration().protocolClasses = [SuperMockRecordingURLProtocol.self]
         NSURLSession.sharedSession().configuration.protocolClasses?.append(SuperMockRecordingURLProtocol)
         
+        SuperMockResponseHelper.mocksFileName  = mocksFile
         SuperMockResponseHelper.bundleForMocks = bundle
         SuperMockResponseHelper.sharedHelper.recording = true
-        
     }
     
     class func endRecording() {

--- a/Pod/Classes/SuperMockResponseHelper.swift
+++ b/Pod/Classes/SuperMockResponseHelper.swift
@@ -22,7 +22,21 @@ class SuperMockResponseHelper: NSObject {
         }
     }
     
+    class var mocksFileName: String? {
+        set {
+            if let fileName = newValue, let url = NSURL(string: fileName) {
+                sharedHelper.mocksFile = url.URLByDeletingPathExtension!.absoluteString
+                return
+            }
+            sharedHelper.mocksFile = "Mocks"
+        }
+        get {
+            return sharedHelper.mocksFile
+        }
+    }
+    
     let fileManager = NSFileManager.defaultManager()
+    var mocksFile: String = "Mocks"
     var bundle : NSBundle? {
         didSet {
             loadDefinitions()
@@ -60,7 +74,7 @@ class SuperMockResponseHelper: NSObject {
             fatalError("You must provide a bundle via NSBundle(class:) or NSBundle.mainBundle() before continuing.")
         }
         
-        if let definitionsPath = bundle.pathForResource("Mocks", ofType: "plist"),
+        if let definitionsPath = bundle.pathForResource(mocksFile, ofType: "plist"),
             let definitions = NSDictionary(contentsOfFile: definitionsPath) as? Dictionary<String,AnyObject>,
             let mocks = definitions["mocks"] as? Dictionary<String,AnyObject>,
             let mimes = definitions["mimes"] as? Dictionary<String,String> {
@@ -237,7 +251,7 @@ extension SuperMockResponseHelper {
         
         let paths = NSSearchPathForDirectoriesInDomains(.DocumentDirectory, .UserDomainMask, true) as NSArray
         let documentsDirectory = paths[0] as? String
-        guard let mockPath = documentsDirectory?.stringByAppendingString("/Mocks.plist"),
+        guard let mockPath = documentsDirectory?.stringByAppendingString("/\(mocksFile)"),
             let bundle = bundle else {
                 return nil
         }


### PR DESCRIPTION
Currently the mocksFile parameter of the func beginMocking is ignored. This pull request will address the issue by setting the custom mocksFile appropriately when we beginMocking or beginRecording.

If this seems reasonable I'll update the sample project to demonstrate its use + add tests.
