### PR TITLE
Convert SuperMock to Swift 3.0

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,5 @@
 language: objective-c
-osx_image: xcode7.1
+osx_image: xcode8.1
 
 install:
 - gem install xcpretty --no-rdoc --no-ri --no-document --quiet

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,5 +4,5 @@ osx_image: xcode8.1
 install:
 - gem install xcpretty --no-rdoc --no-ri --no-document --quiet
 script:
-- set -o pipefail && xcodebuild test -workspace Example/SuperMock.xcworkspace -scheme SuperMock-Example -sdk iphonesimulator9.1 -destination "platform=iOS Simulator,name=iPhone 6" ONLY_ACTIVE_ARCH=YES | xcpretty -c
+- set -o pipefail && xcodebuild test -workspace Example/SuperMock.xcworkspace -scheme SuperMock-Example -sdk iphonesimulator10.1 -destination "platform=iOS Simulator,name=iPhone 6" ONLY_ACTIVE_ARCH=YES | xcpretty -c
 - pod lib lint --quick

--- a/Example/Pods/Pods.xcodeproj/project.pbxproj
+++ b/Example/Pods/Pods.xcodeproj/project.pbxproj
@@ -368,6 +368,20 @@
 			attributes = {
 				LastSwiftUpdateCheck = 0700;
 				LastUpgradeCheck = 0720;
+				TargetAttributes = {
+					428DD4DAFF74821A5419F25A48E2E931 = {
+						LastSwiftMigration = 0800;
+					};
+					92838F6C483958D40EE1438F547C256A = {
+						LastSwiftMigration = 0800;
+					};
+					943778575E9BD2C0C8AF40A66EE83ACC = {
+						LastSwiftMigration = 0800;
+					};
+					F63E72D170EDBFB4C8B60BFD5130E605 = {
+						LastSwiftMigration = 0800;
+					};
+				};
 			};
 			buildConfigurationList = 2D8E8EC45A3A1A1D94AE762CB5028504 /* Build configuration list for PBXProject "Pods" */;
 			compatibilityVersion = "Xcode 3.2";
@@ -493,6 +507,7 @@
 				PRODUCT_NAME = Pods_SuperMock_Tests;
 				SDKROOT = iphoneos;
 				SKIP_INSTALL = YES;
+				SWIFT_VERSION = 3.0;
 				TARGETED_DEVICE_FAMILY = "1,2";
 				VERSIONING_SYSTEM = "apple-generic";
 				VERSION_INFO_PREFIX = "";
@@ -521,6 +536,7 @@
 				PRODUCT_NAME = SuperMock;
 				SDKROOT = iphoneos;
 				SKIP_INSTALL = YES;
+				SWIFT_VERSION = 3.0;
 				TARGETED_DEVICE_FAMILY = "1,2";
 				VERSIONING_SYSTEM = "apple-generic";
 				VERSION_INFO_PREFIX = "";
@@ -584,6 +600,7 @@
 				SDKROOT = iphoneos;
 				SKIP_INSTALL = YES;
 				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
+				SWIFT_VERSION = 3.0;
 				TARGETED_DEVICE_FAMILY = "1,2";
 				VERSIONING_SYSTEM = "apple-generic";
 				VERSION_INFO_PREFIX = "";
@@ -616,6 +633,7 @@
 				SDKROOT = iphoneos;
 				SKIP_INSTALL = YES;
 				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
+				SWIFT_VERSION = 3.0;
 				TARGETED_DEVICE_FAMILY = "1,2";
 				VERSIONING_SYSTEM = "apple-generic";
 				VERSION_INFO_PREFIX = "";
@@ -670,6 +688,7 @@
 				PRODUCT_NAME = SuperMock;
 				SDKROOT = iphoneos;
 				SKIP_INSTALL = YES;
+				SWIFT_VERSION = 3.0;
 				WRAPPER_EXTENSION = bundle;
 			};
 			name = Release;
@@ -699,6 +718,7 @@
 				PRODUCT_NAME = Pods_SuperMock_Example;
 				SDKROOT = iphoneos;
 				SKIP_INSTALL = YES;
+				SWIFT_VERSION = 3.0;
 				TARGETED_DEVICE_FAMILY = "1,2";
 				VERSIONING_SYSTEM = "apple-generic";
 				VERSION_INFO_PREFIX = "";
@@ -713,6 +733,7 @@
 				PRODUCT_NAME = SuperMock;
 				SDKROOT = iphoneos;
 				SKIP_INSTALL = YES;
+				SWIFT_VERSION = 3.0;
 				WRAPPER_EXTENSION = bundle;
 			};
 			name = Debug;
@@ -743,6 +764,7 @@
 				SDKROOT = iphoneos;
 				SKIP_INSTALL = YES;
 				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
+				SWIFT_VERSION = 3.0;
 				TARGETED_DEVICE_FAMILY = "1,2";
 				VERSIONING_SYSTEM = "apple-generic";
 				VERSION_INFO_PREFIX = "";

--- a/Example/Pods/Pods.xcodeproj/project.xcworkspace/contents.xcworkspacedata
+++ b/Example/Pods/Pods.xcodeproj/project.xcworkspace/contents.xcworkspacedata
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Workspace
+   version = "1.0">
+</Workspace>

--- a/Example/SuperMock.xcodeproj/project.pbxproj
+++ b/Example/SuperMock.xcodeproj/project.pbxproj
@@ -309,13 +309,16 @@
 				TargetAttributes = {
 					607FACCF1AFB9204008FA782 = {
 						CreatedOnToolsVersion = 6.3.1;
+						LastSwiftMigration = 0800;
 					};
 					607FACE41AFB9204008FA782 = {
 						CreatedOnToolsVersion = 6.3.1;
+						LastSwiftMigration = 0800;
 						TestTargetID = 607FACCF1AFB9204008FA782;
 					};
 					630ACEC51BE7E1D200D18B4E = {
 						CreatedOnToolsVersion = 7.1;
+						LastSwiftMigration = 0800;
 						TestTargetID = 607FACCF1AFB9204008FA782;
 					};
 				};
@@ -630,6 +633,7 @@
 				MODULE_NAME = ExampleApp;
 				PRODUCT_BUNDLE_IDENTIFIER = "com.superarmstrong.demo.SuperMock-Example";
 				PRODUCT_NAME = "$(TARGET_NAME)";
+				SWIFT_VERSION = 3.0;
 			};
 			name = Debug;
 		};
@@ -644,6 +648,7 @@
 				MODULE_NAME = ExampleApp;
 				PRODUCT_BUNDLE_IDENTIFIER = "com.superarmstrong.demo.SuperMock-Example";
 				PRODUCT_NAME = "$(TARGET_NAME)";
+				SWIFT_VERSION = 3.0;
 			};
 			name = Release;
 		};
@@ -665,6 +670,7 @@
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
 				PRODUCT_BUNDLE_IDENTIFIER = "org.SuperMock.$(PRODUCT_NAME:rfc1034identifier)";
 				PRODUCT_NAME = "$(TARGET_NAME)";
+				SWIFT_VERSION = 3.0;
 				TEST_HOST = "$(BUILT_PRODUCTS_DIR)/SuperMock_Example.app/SuperMock_Example";
 			};
 			name = Debug;
@@ -683,6 +689,7 @@
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
 				PRODUCT_BUNDLE_IDENTIFIER = "org.SuperMock.$(PRODUCT_NAME:rfc1034identifier)";
 				PRODUCT_NAME = "$(TARGET_NAME)";
+				SWIFT_VERSION = 3.0;
 				TEST_HOST = "$(BUILT_PRODUCTS_DIR)/SuperMock_Example.app/SuperMock_Example";
 			};
 			name = Release;
@@ -697,6 +704,7 @@
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
 				PRODUCT_BUNDLE_IDENTIFIER = "com.superarmstrong.SuperMock-ExampleUITests";
 				PRODUCT_NAME = "$(TARGET_NAME)";
+				SWIFT_VERSION = 3.0;
 				TEST_TARGET_NAME = SuperMock_Example;
 				USES_XCTRUNNER = YES;
 			};
@@ -710,6 +718,7 @@
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
 				PRODUCT_BUNDLE_IDENTIFIER = "com.superarmstrong.SuperMock-ExampleUITests";
 				PRODUCT_NAME = "$(TARGET_NAME)";
+				SWIFT_VERSION = 3.0;
 				TEST_TARGET_NAME = SuperMock_Example;
 				USES_XCTRUNNER = YES;
 			};

--- a/Example/SuperMock.xcodeproj/xcshareddata/xcschemes/SuperMock-Example.xcscheme
+++ b/Example/SuperMock.xcodeproj/xcshareddata/xcschemes/SuperMock-Example.xcscheme
@@ -21,7 +21,7 @@
             </BuildableReference>
          </BuildActionEntry>
          <BuildActionEntry
-            buildForTesting = "NO"
+            buildForTesting = "YES"
             buildForRunning = "NO"
             buildForProfiling = "NO"
             buildForArchiving = "NO"
@@ -49,6 +49,16 @@
                BlueprintIdentifier = "630ACEC51BE7E1D200D18B4E"
                BuildableName = "SuperMock_ExampleUITests.xctest"
                BlueprintName = "SuperMock_ExampleUITests"
+               ReferencedContainer = "container:SuperMock.xcodeproj">
+            </BuildableReference>
+         </TestableReference>
+         <TestableReference
+            skipped = "NO">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "607FACE41AFB9204008FA782"
+               BuildableName = "SuperMock_Tests.xctest"
+               BlueprintName = "SuperMock_Tests"
                ReferencedContainer = "container:SuperMock.xcodeproj">
             </BuildableReference>
          </TestableReference>

--- a/Example/SuperMock/AppDelegate.swift
+++ b/Example/SuperMock/AppDelegate.swift
@@ -14,29 +14,29 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
 
     var window: UIWindow?
 
-    func application(application: UIApplication, didFinishLaunchingWithOptions launchOptions: [NSObject: AnyObject]?) -> Bool {
+    func application(_ application: UIApplication, didFinishLaunchingWithOptions launchOptions: [UIApplicationLaunchOptionsKey: Any]?) -> Bool {
 
         // You could conditionally enable/disable this based on target macro.
-        let appBundle = NSBundle(forClass: AppDelegate.self)
+        let appBundle = Bundle(for: AppDelegate.self)
         SuperMock.beginMocking(appBundle)
         //SuperMock.beginRecording(appBundle, policy: .Override)
             
         return true
     }
 
-    func applicationWillResignActive(application: UIApplication) {
+    func applicationWillResignActive(_ application: UIApplication) {
     }
 
-    func applicationDidEnterBackground(application: UIApplication) {
+    func applicationDidEnterBackground(_ application: UIApplication) {
     }
 
-    func applicationWillEnterForeground(application: UIApplication) {
+    func applicationWillEnterForeground(_ application: UIApplication) {
     }
 
-    func applicationDidBecomeActive(application: UIApplication) {
+    func applicationDidBecomeActive(_ application: UIApplication) {
     }
 
-    func applicationWillTerminate(application: UIApplication) {
+    func applicationWillTerminate(_ application: UIApplication) {
     }
 
 

--- a/Example/SuperMock/ViewController.swift
+++ b/Example/SuperMock/ViewController.swift
@@ -12,13 +12,13 @@ class ViewController: UIViewController, UIWebViewDelegate {
 
     @IBOutlet weak var webView: UIWebView!
     
-    let urlSession = NSURLSession.sharedSession()
-    lazy var urlCustomSession : NSURLSession = {
-        let sessionConfiguration = NSURLSessionConfiguration.defaultSessionConfiguration()
+    let urlSession = URLSession.shared
+    lazy var urlCustomSession : URLSession = {
+        let sessionConfiguration = URLSessionConfiguration.default
         
         // This is the key for custom configuration, add the protocols
         sessionConfiguration.addProtocols()
-        return NSURLSession(configuration: sessionConfiguration)
+        return URLSession(configuration: sessionConfiguration)
     }()
 
     @IBOutlet weak var testableButtonOne: UIButton!    
@@ -29,108 +29,108 @@ class ViewController: UIViewController, UIWebViewDelegate {
         updateButtonTitles()
     }
     
-    @IBAction func performRealRequest(sender: AnyObject) {
+    @IBAction func performRealRequest(_ sender: AnyObject) {
         
-        let realURL = NSURL(string: "https://developer.apple.com")!
-        let requestToMock = NSURLRequest(URL: realURL)
+        let realURL = URL(string: "https://developer.apple.com")!
+        let requestToMock = URLRequest(url: realURL)
         
-        let task = urlSession.dataTaskWithRequest(requestToMock) { (data, response, error) -> Void in
+        let task = urlSession.dataTask(with: requestToMock, completionHandler: { (data, response, error) -> Void in
             if let data = data {
-                let stringResponse = NSString(data: data, encoding: NSUTF8StringEncoding) as! String
+                let stringResponse = NSString(data: data, encoding: String.Encoding.utf8.rawValue) as! String
                 print("Real Response : \(stringResponse)")
                 
                 self.webView.loadHTMLString(stringResponse, baseURL: nil)
             }
-        }
+        }) 
         task.resume()
     }
     
-    @IBAction func performMockedRequest(sender: AnyObject) {
+    @IBAction func performMockedRequest(_ sender: AnyObject) {
         
-        let realURL = NSURL(string: "http://mike.kz/")!
-        let requestToMock = NSURLRequest(URL: realURL)
+        let realURL = URL(string: "http://mike.kz/")!
+        let requestToMock = URLRequest(url: realURL)
         
-        let task = urlCustomSession.dataTaskWithRequest(requestToMock) { (data, response, error) -> Void in
+        let task = urlCustomSession.dataTask(with: requestToMock, completionHandler: { (data, response, error) -> Void in
             if let data = data {
-                let stringResponse = NSString(data: data, encoding: NSUTF8StringEncoding) as! String
+                let stringResponse = NSString(data: data, encoding: String.Encoding.utf8.rawValue) as! String
                 print("Mock Response : \(stringResponse)")
                 
                 self.webView.loadHTMLString(stringResponse, baseURL: nil)
             }
-        }
+        }) 
         task.resume()
     }
-    @IBAction func performRealCustomRequest(sender: AnyObject) {
+    @IBAction func performRealCustomRequest(_ sender: AnyObject) {
         
-        let realURL = NSURL(string: "http://apple.com/")!
-        let requestToMock = NSURLRequest(URL: realURL)
+        let realURL = URL(string: "http://apple.com/")!
+        let requestToMock = URLRequest(url: realURL)
         
-        let task = urlCustomSession.dataTaskWithRequest(requestToMock) { (data, response, error) -> Void in
+        let task = urlCustomSession.dataTask(with: requestToMock, completionHandler: { (data, response, error) -> Void in
             if let data = data {
-                let stringResponse = NSString(data: data, encoding: NSUTF8StringEncoding) as! String
+                let stringResponse = NSString(data: data, encoding: String.Encoding.utf8.rawValue) as! String
                 print("Real Response : \(stringResponse)")
                 
                 self.webView.loadHTMLString(stringResponse, baseURL: nil)
             }
-        }
+        }) 
         task.resume()
     }
     
-    @IBAction func performMockedCustomRequest(sender: AnyObject) {
+    @IBAction func performMockedCustomRequest(_ sender: AnyObject) {
         
-        let realURL = NSURL(string: "http://mike.kz/")!
-        let requestToMock = NSURLRequest(URL: realURL)
+        let realURL = URL(string: "http://mike.kz/")!
+        let requestToMock = URLRequest(url: realURL)
         
-        let task = urlSession.dataTaskWithRequest(requestToMock) { (data, response, error) -> Void in
+        let task = urlSession.dataTask(with: requestToMock, completionHandler: { (data, response, error) -> Void in
             if let data = data {
-                let stringResponse = NSString(data: data, encoding: NSUTF8StringEncoding) as! String
+                let stringResponse = NSString(data: data, encoding: String.Encoding.utf8.rawValue) as! String
                 print("Mock Response : \(stringResponse)")
                 
                 self.webView.loadHTMLString(stringResponse, baseURL: nil)
             }
-        }
+        }) 
         task.resume()
     }
     
    func updateButtonTitles() {
         
-        let realURL = NSURL(string: "http://mike.kz/api/layout/buttons/")!
-        let requestToMock = NSURLRequest(URL: realURL)
+        let realURL = URL(string: "http://mike.kz/api/layout/buttons/")!
+        let requestToMock = URLRequest(url: realURL)
         
-        let task = urlSession.dataTaskWithRequest(requestToMock) { (data, response, error) -> Void in
+        let task = urlSession.dataTask(with: requestToMock, completionHandler: { (data, response, error) -> Void in
             if let data = data {
-                let stringResponse = NSString(data: data, encoding: NSUTF8StringEncoding) as! String
+                let stringResponse = NSString(data: data, encoding: String.Encoding.utf8.rawValue) as! String
                 print("Mock Response : \(stringResponse)")
                 
-                dispatch_async(dispatch_get_main_queue(), { () -> Void in
-                    self.testableButtonOne.setTitle(stringResponse, forState: .Normal)
+                DispatchQueue.main.async(execute: { () -> Void in
+                    self.testableButtonOne.setTitle(stringResponse, for: UIControlState())
                     self.testableButtonOne.accessibilityValue = stringResponse
                 })
             }
-        }
+        }) 
         task.resume()
     }
     // TODO: it is already working :)
     // TODO: The below (UIWebView Mocking)doesn't work in this version, but will in the next.
     func performSampleWebViewLoad() {
         
-        let realURL = NSURL(string: "http://mike.kz/")!
-        let realRequest = NSURLRequest(URL: realURL)
+        let realURL = URL(string: "http://mike.kz/")!
+        let realRequest = URLRequest(url: realURL)
         webView.loadRequest(realRequest)
         webView.delegate = self
     }
     
     // MARK: UIWebViewDelegate
     
-    func webView(webView: UIWebView, didFailLoadWithError error: NSError?) {
-        print("Webview Error : \(error?.localizedDescription)")
+    func webView(_ webView: UIWebView, didFailLoadWithError error: Error) {
+        print("Webview Error : \(error.localizedDescription)")
     }
     
-    func webViewDidFinishLoad(webView: UIWebView) {
+    func webViewDidFinishLoad(_ webView: UIWebView) {
         print("Webview Finished Loading")
     }
     
-    func webViewDidStartLoad(webView: UIWebView) {
+    func webViewDidStartLoad(_ webView: UIWebView) {
         print("Webview Started Loading")
     }
 }

--- a/Example/SuperMock_ExampleUITests/SuperMock_ExampleUITests.swift
+++ b/Example/SuperMock_ExampleUITests/SuperMock_ExampleUITests.swift
@@ -27,11 +27,11 @@ class SuperMock_ExampleUITests: XCTestCase {
 
         // Naive UI test to demonstrate how the mock is used here to validate. Should really be testing the button value.
         
-        let buttonOne = app.buttons.matchingIdentifier("testableButtonOne").element
+        let buttonOne = app.buttons.matching(identifier: "testableButtonOne").element
         let existsPredicate = NSPredicate(format: "exists == 1")
         
-        expectationForPredicate(existsPredicate, evaluatedWithObject: buttonOne, handler: nil)
-        waitForExpectationsWithTimeout(3.0, handler: nil)
+        expectation(for: existsPredicate, evaluatedWith: buttonOne, handler: nil)
+        waitForExpectations(timeout: 3.0, handler: nil)
         
         let buttonOneText = buttonOne.value as! String
         XCTAssert(buttonOneText == "MOCKTITLE1","Button doesn't match expected value from mock")

--- a/Example/Tests/Tests.swift
+++ b/Example/Tests/Tests.swift
@@ -7,17 +7,17 @@ class Tests: XCTestCase {
     override func setUp() {
         super.setUp()
         
-        SuperMock.beginMocking(NSBundle(forClass: AppDelegate.self))
+        SuperMock.beginMocking(Bundle(for: AppDelegate.self))
     }
     
     override func tearDown() {
         super.tearDown()
         
-        let paths = NSSearchPathForDirectoriesInDomains(.DocumentDirectory, .UserDomainMask, true) as NSArray
+        let paths = NSSearchPathForDirectoriesInDomains(.documentDirectory, .userDomainMask, true) as NSArray
         let documentsDirectory = paths[0] as? String
-        let filePath = documentsDirectory?.stringByAppendingString("/Mocks.plist")
+        let filePath = (documentsDirectory)! + "/Mocks.plist"
         
-        do {try NSFileManager.defaultManager().removeItemAtPath(filePath!)} catch{}
+        do {try FileManager.default.removeItem(atPath: filePath)} catch{}
         SuperMock.endMocking()
     }
     
@@ -25,16 +25,16 @@ class Tests: XCTestCase {
         
         let responseHelper = SuperMockResponseHelper.sharedHelper
         
-        let url = NSURL(string: "http://mike.kz/")!
-        let realRequest = NSMutableURLRequest(URL: url)
-        realRequest.HTTPMethod = "GET"
-        let mockRequest = responseHelper.mockRequest(realRequest)
+        let url = URL(string: "http://mike.kz/")!
+        let realRequest = NSMutableURLRequest(url: url)
+        realRequest.httpMethod = "GET"
+        let mockRequest = responseHelper.mockRequest(realRequest as URLRequest)
         
-        let bundle = NSBundle(forClass: AppDelegate.self)
-        let pathToExpectedData = bundle.pathForResource("sample", ofType: "html")!
+        let bundle = Bundle(for: AppDelegate.self)
+        let pathToExpectedData = bundle.path(forResource: "sample", ofType: "html")!
         
-        let expectedData = NSData(contentsOfFile: pathToExpectedData)
-        let returnedData = responseHelper.responseForMockRequest(mockRequest)
+        let expectedData = try? Data(contentsOf: URL(fileURLWithPath: pathToExpectedData))
+        let returnedData = responseHelper.responseForMockRequest(mockRequest as URLRequest!)
         
         XCTAssert(expectedData == returnedData, "Expected data not received for mock.")
         
@@ -44,16 +44,16 @@ class Tests: XCTestCase {
         
         let responseHelper = SuperMockResponseHelper.sharedHelper
         
-        let url = NSURL(string: "http://mike.kz/")!
-        let realRequest = NSMutableURLRequest(URL: url)
-        realRequest.HTTPMethod = "POST"
-        let mockRequest = responseHelper.mockRequest(realRequest)
+        let url = URL(string: "http://mike.kz/")!
+        let realRequest = NSMutableURLRequest(url: url)
+        realRequest.httpMethod = "POST"
+        let mockRequest = responseHelper.mockRequest(realRequest as URLRequest)
         
-        let bundle = NSBundle(forClass: AppDelegate.self)
-        let pathToExpectedData = bundle.pathForResource("samplePOST", ofType: "html")!
+        let bundle = Bundle(for: AppDelegate.self)
+        let pathToExpectedData = bundle.path(forResource: "samplePOST", ofType: "html")!
         
-        let expectedData = NSData(contentsOfFile: pathToExpectedData)
-        let returnedData = responseHelper.responseForMockRequest(mockRequest)
+        let expectedData = try? Data(contentsOf: URL(fileURLWithPath: pathToExpectedData))
+        let returnedData = responseHelper.responseForMockRequest(mockRequest as URLRequest!)
         
         XCTAssert(expectedData == returnedData, "Expected data not received for mock.")
         
@@ -62,47 +62,47 @@ class Tests: XCTestCase {
     func testValidRequestWithNoMockReturnsOriginalRequest() {
         let responseHelper = SuperMockResponseHelper.sharedHelper
         
-        let url = NSURL(string: "http://nomockavailable.com")!
-        let realRequest = NSURLRequest(URL: url)
+        let url = URL(string: "http://nomockavailable.com")!
+        let realRequest = URLRequest(url: url)
         let mockRequest = responseHelper.mockRequest(realRequest)
         
-        XCTAssert(realRequest == mockRequest, "Original request should be returned when no mock is available.")
+        XCTAssert(realRequest == mockRequest as URLRequest, "Original request should be returned when no mock is available.")
     }
     
     func testValidRequestWithMockReturnsDifferentRequest() {
         let responseHelper = SuperMockResponseHelper.sharedHelper
         
-        let url = NSURL(string: "http://mike.kz/")!
-        let realRequest = NSURLRequest(URL: url)
+        let url = URL(string: "http://mike.kz/")!
+        let realRequest = URLRequest(url: url)
         let mockRequest = responseHelper.mockRequest(realRequest)
         
-        XCTAssert(realRequest != mockRequest, "Different request should be returned when a mock is available.")
+        XCTAssert(realRequest != mockRequest as URLRequest, "Different request should be returned when a mock is available.")
     }
     
     func testValidRequestWithMockReturnsFileURLRequest() {
         let responseHelper = SuperMockResponseHelper.sharedHelper
         
-        let url = NSURL(string: "http://mike.kz/")!
-        let realRequest = NSURLRequest(URL: url)
+        let url = URL(string: "http://mike.kz/")!
+        let realRequest = URLRequest(url: url)
         let mockRequest = responseHelper.mockRequest(realRequest)
         
-        XCTAssert(mockRequest.URL!.fileURL, "fileURL mocked request should be returned when a mock is available.")
+        XCTAssertNotNil(mockRequest.url?.isFileURL, "baseURL mocked request should be returned when a mock is available.")
     }
     
     func testRecordDataAsMock() {
         
-        let url = NSURL(string: "http://mike.kz/Daniele")!
-        let realRequest = NSURLRequest(URL: url)
+        let url = URL(string: "http://mike.kz/Daniele")!
+        let realRequest = URLRequest(url: url)
         
         let responseString = "Something to put into the response field"
         
         let responseHelper = SuperMockResponseHelper.sharedHelper
-        let expectedData = responseString.dataUsingEncoding(NSUTF8StringEncoding)!
+        let expectedData = responseString.data(using: String.Encoding.utf8)!
         
         responseHelper.recordDataForRequest(expectedData, request: realRequest)
         
         let mockRequest = responseHelper.mockRequest(realRequest)
-        let returnedData = responseHelper.responseForMockRequest(mockRequest)
+        let returnedData = responseHelper.responseForMockRequest(mockRequest as URLRequest!)
         
         XCTAssert(expectedData == returnedData, "Expected data not received for mock.")
         
@@ -110,41 +110,41 @@ class Tests: XCTestCase {
     
     func testMockResponseReturnNilIfNoHeadersFile() {
         
-        let url = NSURL(string: "http://mike.kz/Daniele")!
-        let realRequest = NSURLRequest(URL: url)
+        let url = URL(string: "http://mike.kz/Daniele")!
+        let realRequest = URLRequest(url: url)
         
         XCTAssertNil(SuperMockResponseHelper.sharedHelper.mockResponse(realRequest), "The response should be nil because does not exist file")
         
-        let paths = NSSearchPathForDirectoriesInDomains(.DocumentDirectory, .UserDomainMask, true) as NSArray
+        let paths = NSSearchPathForDirectoriesInDomains(.documentDirectory, .userDomainMask, true) as NSArray
         let documentsDirectory = paths[0] as? String
-        let filePath = documentsDirectory?.stringByAppendingString("/__mike.kz_Daniele")
+        let filePath = (documentsDirectory)! + "/__mike.kz_Daniele"
         
-        do {try NSFileManager.defaultManager().removeItemAtPath(filePath!)} catch{}
+        do {try FileManager.default.removeItem(atPath: filePath)} catch{}
     }
     
     func testMockResponseReturnedMockedHTTPResponse() {
         
-        let url = NSURL(string: "http://mike.kz/")!
-        let realRequest = NSMutableURLRequest(URL: url)
+        let url = URL(string: "http://mike.kz/")!
+        let realRequest = NSMutableURLRequest(url: url)
         
-        XCTAssertNotNil(SuperMockResponseHelper.sharedHelper.mockResponse(realRequest), "The response should not be nil because the file exist")
+        XCTAssertNotNil(SuperMockResponseHelper.sharedHelper.mockResponse(realRequest as URLRequest), "The response should not be nil because the file exist")
     }
     
     func testRecordResponseHeadersForRequestRecordFile() {
         
-        let url = NSURL(string: "http://mike.kz/RecordedResponseHeaders")!
-        let realRequest = NSURLRequest(URL: url)
-        let response = NSHTTPURLResponse(URL: url, statusCode: 200, HTTPVersion: nil, headerFields: realRequest.allHTTPHeaderFields)
+        let url = URL(string: "http://mike.kz/RecordedResponseHeaders")!
+        let realRequest = URLRequest(url: url)
+        let response = HTTPURLResponse(url: url, statusCode: 200, httpVersion: nil, headerFields: realRequest.allHTTPHeaderFields)
         
         SuperMockResponseHelper.sharedHelper.recordResponseHeadersForRequest(["Connection":"Keep-Alive"], request: realRequest, response: response!)
         
-        let paths = NSSearchPathForDirectoriesInDomains(.DocumentDirectory, .UserDomainMask, true) as NSArray
+        let paths = NSSearchPathForDirectoriesInDomains(.documentDirectory, .userDomainMask, true) as NSArray
         let documentsDirectory = paths[0] as? String
-        let filePath = documentsDirectory?.stringByAppendingString("/__mike.kz_RecordedResponseHeaders")
+        let filePath = (documentsDirectory)! + "/__mike.kz_RecordedResponseHeaders"
         
-        XCTAssertTrue(NSFileManager.defaultManager().fileExistsAtPath(filePath!), "Headers file need to be created")
+        XCTAssertTrue(FileManager.default.fileExists(atPath: filePath), "Headers file need to be created")
         
-        do {try NSFileManager.defaultManager().removeItemAtPath(filePath!)} catch{}
+        do {try FileManager.default.removeItem(atPath: filePath)} catch{}
     }
     
 }
@@ -154,36 +154,36 @@ extension Tests {
     
     func testMockedFilePathReturnFilePathForExistingFile() {
         
-        let paths = NSSearchPathForDirectoriesInDomains(.DocumentDirectory, .UserDomainMask, true) as NSArray
+        let paths = NSSearchPathForDirectoriesInDomains(.documentDirectory, .userDomainMask, true) as NSArray
         let documentsDirectory = paths[0] as? String
-        let filePath = documentsDirectory?.stringByAppendingString("/__www.danieleforlani.net_c1d94.txt")
+        let filePath = (documentsDirectory)! + "/__www.danieleforlani.net_c1d94.txt"
         let string = "Something to save as data"
         
-        try! string.writeToFile(filePath!, atomically: true, encoding: NSUTF8StringEncoding)
+        try! string.write(toFile: filePath, atomically: true, encoding: String.Encoding.utf8)
         
-        SuperMock.beginRecording(NSBundle(forClass: AppDelegate.self), policy: .Override)
+        SuperMock.beginRecording(Bundle(for: AppDelegate.self), policy: .Override)
         
-        XCTAssertTrue(FileHelper.mockedResponseFilePath(NSURL(string: "http://www.danieleforlani.net/c1d94")!) == filePath!, "Expected the right path for existing file")
+        XCTAssertTrue(FileHelper.mockedResponseFilePath(URL(string: "http://www.danieleforlani.net/c1d94")!) == filePath, "Expected the right path for existing file")
         SuperMock.endRecording()
         
-        XCTAssertTrue(NSFileManager.defaultManager().fileExistsAtPath(filePath!), "Plist file need to be copied if does exist in bundle")
+        XCTAssertTrue(FileManager.default.fileExists(atPath: filePath), "Plist file need to be copied if does exist in bundle")
         
-        do {try NSFileManager.defaultManager().removeItemAtPath(filePath!)} catch{}
+        do {try FileManager.default.removeItem(atPath: filePath)} catch{}
     }
     
     func testMockedFilePathReturnFilePathHeaderForExistingFile() {
         
-        let paths = NSSearchPathForDirectoriesInDomains(.DocumentDirectory, .UserDomainMask, true) as NSArray
+        let paths = NSSearchPathForDirectoriesInDomains(.documentDirectory, .userDomainMask, true) as NSArray
         let documentsDirectory = paths[0] as? String
-        let filePath = documentsDirectory?.stringByAppendingString("/__www.danieleforlani.net_c1d94")
+        let filePath = (documentsDirectory)! + "/__www.danieleforlani.net_c1d94"
         let string = "Something to save as data"
         
-        try! string.writeToFile(filePath!, atomically: true, encoding: NSUTF8StringEncoding)
+        try! string.write(toFile: filePath, atomically: true, encoding: String.Encoding.utf8)
         
         
-        XCTAssertTrue(FileHelper.mockedResponseHeadersFilePath(NSURL(string: "http://www.danieleforlani.net/c1d94")!) == filePath!, "Expected the right path for existing file")
+        XCTAssertTrue(FileHelper.mockedResponseHeadersFilePath(URL(string: "http://www.danieleforlani.net/c1d94")!) == filePath, "Expected the right path for existing file")
         
-        do {try NSFileManager.defaultManager().removeItemAtPath(filePath!)} catch{}
+        do {try FileManager.default.removeItem(atPath: filePath)} catch{}
     }
     
     func testMockFileOutOfBundle_NoMockFile_CreateMockFile() {
@@ -191,13 +191,14 @@ extension Tests {
         SuperMockResponseHelper.sharedHelper.mocksFile = "NewMock"
         let _ = FileHelper.mockFileOutOfBundle()
         
-        let paths = NSSearchPathForDirectoriesInDomains(.DocumentDirectory, .UserDomainMask, true) as NSArray
-        let documentsDirectory = paths[0] as? String
-        let mockPath =  documentsDirectory?.stringByAppendingString("/\(SuperMockResponseHelper.sharedHelper.mocksFile).plist")
+        let paths = NSSearchPathForDirectoriesInDomains(.documentDirectory, .userDomainMask, true) as NSArray
+        let documentsDirectory = paths[0] as! String
         
-        XCTAssertTrue(NSFileManager.defaultManager().fileExistsAtPath(mockPath!), "Plist file need to be created if does not exist")
+        let mockPath = "\(documentsDirectory)/\(SuperMockResponseHelper.sharedHelper.mocksFile).plist"
         
-        do {try NSFileManager.defaultManager().removeItemAtPath(mockPath!)} catch{}
+        XCTAssertTrue(FileManager.default.fileExists(atPath: mockPath), "Plist file need to be created if does not exist")
+        
+        do {try FileManager.default.removeItem(atPath: mockPath)} catch{}
     }
     
     func testMockFileOutOfBundle_CopyMockFile() {
@@ -205,32 +206,32 @@ extension Tests {
         SuperMockResponseHelper.sharedHelper.mocksFile = "Mock"
         let _ = FileHelper.mockFileOutOfBundle()
         
-        let paths = NSSearchPathForDirectoriesInDomains(.DocumentDirectory, .UserDomainMask, true) as NSArray
-        let documentsDirectory = paths[0] as? String
-        let mockPath =  documentsDirectory?.stringByAppendingString("/\(SuperMockResponseHelper.sharedHelper.mocksFile).plist")
+        let paths = NSSearchPathForDirectoriesInDomains(.documentDirectory, .userDomainMask, true) as NSArray
+        let documentsDirectory = paths[0] as! String
+        let mockPath = "\(documentsDirectory)/\(SuperMockResponseHelper.sharedHelper.mocksFile).plist"
         
-        XCTAssertTrue(NSFileManager.defaultManager().fileExistsAtPath(mockPath!), "Plist file need to be copied if does exist in bundle")
+        XCTAssertTrue(FileManager.default.fileExists(atPath: mockPath), "Plist file need to be copied if does exist in bundle")
         
-        do {try NSFileManager.defaultManager().removeItemAtPath(mockPath!)} catch{}
+        do {try FileManager.default.removeItem(atPath: mockPath)} catch{}
     }
     
     func testMockFileOutOfBundle_Exist_ReturnCorrectpath() {
         
         SuperMockResponseHelper.sharedHelper.mocksFile = "FakeMock"
         
-        let paths = NSSearchPathForDirectoriesInDomains(.DocumentDirectory, .UserDomainMask, true) as NSArray
-        let documentsDirectory = paths[0] as? String
-        let mockPath =  documentsDirectory?.stringByAppendingString("/\(SuperMockResponseHelper.sharedHelper.mocksFile).plist")
+        let paths = NSSearchPathForDirectoriesInDomains(.documentDirectory, .userDomainMask, true) as NSArray
+        let documentsDirectory = paths[0] as! String
+        let mockPath = "\(documentsDirectory)/\(SuperMockResponseHelper.sharedHelper.mocksFile).plist"
         
         let string = "Fake Mock File"
         
-        try! string.writeToFile(mockPath!, atomically: true, encoding: NSUTF8StringEncoding)
+        try? string.write(toFile: mockPath, atomically: true, encoding: String.Encoding.utf8)
         
         let filePath = FileHelper.mockFileOutOfBundle()
         
         XCTAssertTrue(filePath == mockPath, "Plist file need to be copied if does exist in bundle")
         
-        do {try NSFileManager.defaultManager().removeItemAtPath(mockPath!)} catch{}
+        do {try FileManager.default.removeItem(atPath: mockPath)} catch{}
     }
     
     

--- a/Pod/Classes/SuperMock.swift
+++ b/Pod/Classes/SuperMock.swift
@@ -8,7 +8,7 @@
 
 import UIKit
 
-public class SuperMock: NSObject {
+open class SuperMock: NSObject {
     
     /**
      Begin stubbing responses to NSURLConnection / NSURLSession methods.
@@ -21,22 +21,22 @@ public class SuperMock: NSObject {
      
      - returns: void
      */
-    public class func beginMocking(bundle: NSBundle!, mocksFile: String? = "Mocks.plist") {
+    open class func beginMocking(_ bundle: Bundle!, mocksFile: String? = "Mocks.plist") {
         
-        NSURLProtocol.registerClass(SuperMockURLProtocol)
-        NSURLSessionConfiguration.defaultSessionConfiguration().protocolClasses = [SuperMockURLProtocol.self]
-        NSURLSession.sharedSession().configuration.protocolClasses?.append(SuperMockURLProtocol)
+        URLProtocol.registerClass(SuperMockURLProtocol)
+        URLSessionConfiguration.default.protocolClasses = [SuperMockURLProtocol.self]
+        URLSession.shared.configuration.protocolClasses?.append(SuperMockURLProtocol)
         
         SuperMockResponseHelper.mocksFileName  = mocksFile
         SuperMockResponseHelper.bundleForMocks = bundle
         SuperMockResponseHelper.sharedHelper.mocking = true
     }
     
-    public class func beginRecording(bundle: NSBundle?, mocksFile: String? = "Mocks.plist", policy: RecordPolicy) {
+    open class func beginRecording(_ bundle: Bundle?, mocksFile: String? = "Mocks.plist", policy: RecordPolicy) {
         
-        NSURLProtocol.registerClass(SuperMockRecordingURLProtocol)
-        NSURLSessionConfiguration.defaultSessionConfiguration().protocolClasses = [SuperMockRecordingURLProtocol.self]
-        NSURLSession.sharedSession().configuration.protocolClasses?.append(SuperMockRecordingURLProtocol)
+        URLProtocol.registerClass(SuperMockRecordingURLProtocol)
+        URLSessionConfiguration.default.protocolClasses = [SuperMockRecordingURLProtocol.self]
+        URLSession.shared.configuration.protocolClasses?.append(SuperMockRecordingURLProtocol)
         
         SuperMockResponseHelper.mocksFileName  = mocksFile
         SuperMockResponseHelper.bundleForMocks = bundle
@@ -44,8 +44,8 @@ public class SuperMock: NSObject {
         SuperMockResponseHelper.sharedHelper.recordPolicy = policy
     }
     
-    public class func endRecording() {
-        NSURLProtocol.unregisterClass(SuperMockRecordingURLProtocol)
+    open class func endRecording() {
+        URLProtocol.unregisterClass(SuperMockRecordingURLProtocol)
         SuperMockResponseHelper.sharedHelper.recording = false
     }
     
@@ -54,8 +54,8 @@ public class SuperMock: NSObject {
      
      - returns: void
      */
-    public class func endMocking() {
-        NSURLProtocol.unregisterClass(SuperMockURLProtocol)
+    open class func endMocking() {
+        URLProtocol.unregisterClass(SuperMockURLProtocol)
     }
 
 }

--- a/Pod/Classes/SuperMockNSURLRequestExtension.swift
+++ b/Pod/Classes/SuperMockNSURLRequestExtension.swift
@@ -8,7 +8,7 @@
 
 import Foundation
 
-extension NSURLRequest {
+extension URLRequest {
     
     /**
      Call to determine whether or not a NSURLRequest has an applicable mock setup in Mocks.plist
@@ -18,7 +18,7 @@ extension NSURLRequest {
     func hasMock() -> Bool {
         
         let mockRequest = SuperMockResponseHelper.sharedHelper.mockRequest(self)
-        if mockRequest.URL == self.URL {
+        if mockRequest.url == self.url {
             return false
         }
         

--- a/Pod/Classes/SuperMockNSURLSessionConfigurationExtension.swift
+++ b/Pod/Classes/SuperMockNSURLSessionConfigurationExtension.swift
@@ -8,7 +8,7 @@
 
 import Foundation
 
-extension NSURLSessionConfiguration {
+extension URLSessionConfiguration {
     
     public func addProtocols() {
         
@@ -21,7 +21,7 @@ extension NSURLSessionConfiguration {
             protocolClasses.append(SuperMockURLProtocol.self)
         }
         if let protocols = self.protocolClasses {
-            protocolClasses.appendContentsOf(protocols)
+            protocolClasses.append(contentsOf: protocols)
         }
         self.protocolClasses = protocolClasses
     }

--- a/Pod/Classes/SuperMockResponseHelper.swift
+++ b/Pod/Classes/SuperMockResponseHelper.swift
@@ -18,10 +18,10 @@ class SuperMockResponseHelper: NSObject {
     
     static let sharedHelper = SuperMockResponseHelper()
     var mocking = false
-    private let dataKey = "data"
-    private let responseKey = "response"
+    fileprivate let dataKey = "data"
+    fileprivate let responseKey = "response"
     
-    class var bundleForMocks : NSBundle? {
+    class var bundleForMocks : Bundle? {
         set {
         sharedHelper.bundle = newValue
         }
@@ -32,8 +32,8 @@ class SuperMockResponseHelper: NSObject {
     
     class var mocksFileName: String? {
         set {
-        if let fileName = newValue, let url = NSURL(string: fileName) {
-        sharedHelper.mocksFile = url.URLByDeletingPathExtension!.absoluteString
+        if let fileName = newValue, let url = URL(string: fileName) {
+        sharedHelper.mocksFile = url.deletingPathExtension().absoluteString
         return
         }
         sharedHelper.mocksFile = "Mocks"
@@ -43,9 +43,9 @@ class SuperMockResponseHelper: NSObject {
         }
     }
     
-    let fileManager = NSFileManager.defaultManager()
+    let fileManager = FileManager.default
     var mocksFile: String = "Mocks"
-    var bundle : NSBundle? {
+    var bundle : Bundle? {
         didSet {
             loadDefinitions()
         }
@@ -77,7 +77,7 @@ class SuperMockResponseHelper: NSObject {
             fatalError("You must provide a bundle via NSBundle(class:) or NSBundle.mainBundle() before continuing.")
         }
         
-        if let definitionsPath = bundle.pathForResource(mocksFile, ofType: "plist"),
+        if let definitionsPath = bundle.path(forResource: mocksFile, ofType: "plist"),
             let definitions = NSDictionary(contentsOfFile: definitionsPath) as? Dictionary<String,AnyObject>,
             let mocks = definitions["mocks"] as? Dictionary<String,AnyObject>,
             let mimes = definitions["mimes"] as? Dictionary<String,String> {
@@ -93,19 +93,19 @@ class SuperMockResponseHelper: NSObject {
      
      - returns: NSURLRequest with manipulated resource identifier.
      */
-    func mockRequest(request: NSURLRequest) -> NSURLRequest {
-        guard let url = request.URL else {
-            return request
+    func mockRequest(_ request: URLRequest) -> NSURLRequest {
+        guard let url = request.url else {
+            return request as NSURLRequest
         }
-        let requestMethod = RequestMethod(rawValue: request.HTTPMethod!)!
+        let requestMethod = RequestMethod(rawValue: request.httpMethod!)!
         
         let mockURL = mockURLForRequestURL(url, requestMethod: requestMethod, mocks: mocks)
-        if mockURL == request.URL {
-            return request
+        if mockURL == request.url {
+            return request as NSURLRequest
         }
         
-        let mocked = request.mutableCopy() as! NSMutableURLRequest
-        mocked.URL = mockURL
+        let mocked = (request as NSURLRequest).mutableCopy() as! NSMutableURLRequest
+        mocked.url = mockURL
         mocked.setValue("true", forHTTPHeaderField: "X-SUPERMOCK-MOCKREQUEST")
         let injectableRequest = mocked.copy() as! NSURLRequest
         
@@ -113,17 +113,17 @@ class SuperMockResponseHelper: NSObject {
         
     }
     
-    private func mockURLForRequestURL(url: NSURL, requestMethod: RequestMethod, mocks: Dictionary<String,AnyObject>) -> NSURL? {
+    fileprivate func mockURLForRequestURL(_ url: URL, requestMethod: RequestMethod, mocks: Dictionary<String,AnyObject>) -> URL? {
         
         return mockURLForRequestURL(url, requestMethod: requestMethod, mocks: mocks, isData: true)
     }
     
-    private func mockURLForRequestRestponseURL(url: NSURL, requestMethod: RequestMethod, mocks: Dictionary<String,AnyObject>) -> NSURL? {
+    fileprivate func mockURLForRequestRestponseURL(_ url: URL, requestMethod: RequestMethod, mocks: Dictionary<String,AnyObject>) -> URL? {
         
         return mockURLForRequestURL(url, requestMethod: requestMethod, mocks: mocks, isData: false)
     }
     
-    private func mockURLForRequestURL(url: NSURL, requestMethod: RequestMethod, mocks: Dictionary<String,AnyObject>, isData: Bool) -> NSURL? {
+    fileprivate func mockURLForRequestURL(_ url: URL, requestMethod: RequestMethod, mocks: Dictionary<String,AnyObject>, isData: Bool) -> URL? {
         
         guard let definitionsForMethod = mocks[requestMethod.rawValue] as? Dictionary<String,AnyObject> else {
             fatalError("Couldn't find definitions for request: \(requestMethod) make sure to create a node for it in the plist and include your plist file in the correct target")
@@ -131,22 +131,22 @@ class SuperMockResponseHelper: NSObject {
         
         if let responseFiles = definitionsForMethod[url.absoluteString] as? [String:String] {
             
-            if let responseFile = responseFiles[dataKey], let responsePath = bundle?.pathForResource(responseFile, ofType: "") where isData {
-                return NSURL(fileURLWithPath: responsePath)
+            if let responseFile = responseFiles[dataKey], let responsePath = bundle?.path(forResource: responseFile, ofType: "") , isData {
+                return URL(fileURLWithPath: responsePath)
             }
             
-            if let responseFile = responseFiles[responseKey], let responsePath = bundle?.pathForResource(responseFile, ofType: "") where !isData {
-                return NSURL(fileURLWithPath: responsePath)
+            if let responseFile = responseFiles[responseKey], let responsePath = bundle?.path(forResource: responseFile, ofType: "") , !isData {
+                return URL(fileURLWithPath: responsePath)
             }
             
         } else {
             
-            if let responsePath = FileHelper.mockedResponseHeadersFilePath(url) where !isData && NSFileManager.defaultManager().fileExistsAtPath(responsePath) {
-                return NSURL(fileURLWithPath: responsePath)
+            if let responsePath = FileHelper.mockedResponseHeadersFilePath(url) , !isData && FileManager.default.fileExists(atPath: responsePath) {
+                return URL(fileURLWithPath: responsePath)
             }
             
-            if let responsePath = FileHelper.mockedResponseFilePath(url) where isData && NSFileManager.defaultManager().fileExistsAtPath(responsePath){
-                return NSURL(fileURLWithPath: responsePath)
+            if let responsePath = FileHelper.mockedResponseFilePath(url) , isData && FileManager.default.fileExists(atPath: responsePath){
+                return URL(fileURLWithPath: responsePath)
             }
         }
         return url
@@ -161,13 +161,13 @@ class SuperMockResponseHelper: NSObject {
      
      - returns: NSData containing the mock response.
      */
-    func responseForMockRequest(request: NSURLRequest!) -> NSData? {
+    func responseForMockRequest(_ request: URLRequest!) -> Data? {
         
-        if request.URL?.fileURL == false {
+        if request.url?.isFileURL == false {
             fatalError("You should only call this on mocked URLs")
         }
         
-        return mockedResponse(request.URL!)
+        return mockedResponse(request.url!)
     }
     
     /**
@@ -179,10 +179,10 @@ class SuperMockResponseHelper: NSObject {
      
      - returns: String containing RFC 6838 compliant mime.type
      */
-    func mimeType(url: NSURL!) -> String {
+    func mimeType(_ url: URL!) -> String {
         
-        if let pathExtension = url.pathExtension where pathExtension.characters.count > 0 {
-            if let mime = mimes[pathExtension] {
+        if url.pathExtension.characters.count > 0 {
+            if let mime = mimes[url.pathExtension] {
                 return mime
             }
             return ""
@@ -190,8 +190,8 @@ class SuperMockResponseHelper: NSObject {
         return "text/plain"
     }
     
-    private func mockedResponse(url: NSURL) -> NSData? {
-        if let data = NSData(contentsOfURL: url) {
+    fileprivate func mockedResponse(_ url: URL) -> Data? {
+        if let data = try? Data(contentsOf: url) {
             return data
         }
         return nil
@@ -203,38 +203,38 @@ class SuperMockResponseHelper: NSObject {
      :param: data    data to save into the file
      :param: request Rapresent the request called for obtain the data
      */
-    func recordDataForRequest(data: NSData?, request: NSURLRequest) {
+    func recordDataForRequest(_ data: Data?, request: URLRequest) {
         
-        guard let url = request.URL else {
+        guard let url = request.url else {
             return
         }
         recordResponseForRequest(data, request: request, responseFile: FileHelper.mockedResponseFileName(url), responsePath: FileHelper.mockedResponseFilePath(url), key: dataKey)
     }
     
-    private func recordResponseHeadersDataForRequest(data: NSData?, request: NSURLRequest) {
+    fileprivate func recordResponseHeadersDataForRequest(_ data: Data?, request: URLRequest) {
         
-        guard let url = request.URL else {
+        guard let url = request.url else {
             return
         }
         recordResponseForRequest(data, request: request, responseFile: FileHelper.mockedResponseHeadersFileName(url), responsePath: FileHelper.mockedResponseHeadersFilePath(url), key: responseKey)
     }
     
-    private func recordResponseForRequest(data: NSData?, request: NSURLRequest, responseFile: String?, responsePath: String?, key: String) {
+    fileprivate func recordResponseForRequest(_ data: Data?, request: URLRequest, responseFile: String?, responsePath: String?, key: String) {
         
         guard let definitionsPath = FileHelper.mockFileOutOfBundle(),
             let definitions = NSMutableDictionary(contentsOfFile: definitionsPath),
-            let absoluteString = request.URL?.absoluteString,
-            let httpMethod = request.HTTPMethod,
+            let absoluteString = request.url?.absoluteString,
+            let httpMethod = request.httpMethod,
             let responseFile = responseFile,
             let responsePath = responsePath,
             let data = data else {
                 return
         }
-        data.writeToFile(responsePath, atomically: true)
+        try? data.write(to: URL(fileURLWithPath: responsePath), options: [.atomic])
         let keyPath = "mocks.\(httpMethod)"
-        if let mocks = definitions.valueForKeyPath(keyPath) as? NSMutableDictionary {
+        if let mocks = definitions.value(forKeyPath: keyPath) as? NSMutableDictionary {
             
-            if let _ = mocks["\(absoluteString)"] where recordPolicy == .Record {
+            if let _ = mocks["\(absoluteString)"], recordPolicy == .Record {
                 return
             }
             
@@ -244,7 +244,7 @@ class SuperMockResponseHelper: NSObject {
                 mocks["\(absoluteString)"] = [key:responseFile]
             }
             
-            if !definitions.writeToFile(definitionsPath, atomically: true) {
+            if !definitions.write(toFile: definitionsPath, atomically: true) {
                 print("Error writning the file, permission problems?")
             }
         }
@@ -257,11 +257,11 @@ class SuperMockResponseHelper: NSObject {
      
      - returns: Mocked response set with the HTTPHEaders of the response recorded
      */
-    func mockResponse(request: NSURLRequest) -> NSURLResponse? {
+    func mockResponse(_ request: URLRequest) -> URLResponse? {
         
-        let requestMethod = RequestMethod(rawValue: request.HTTPMethod!)!
+        let requestMethod = RequestMethod(rawValue: request.httpMethod!)!
         
-        guard let mockedHeaderFields = mockedHeaderFields(request.URL!, requestMethod: requestMethod, mocks: mocks) else {
+        guard let mockedHeaderFields = mockedHeaderFields(request.url!, requestMethod: requestMethod, mocks: mocks) else {
             return nil
         }
         var statusCode = 200
@@ -269,7 +269,7 @@ class SuperMockResponseHelper: NSObject {
             statusCode = responseStatus
         }
         
-        let mockedResponse = NSHTTPURLResponse(URL: request.URL!, statusCode: statusCode, HTTPVersion: nil, headerFields: mockedHeaderFields )
+        let mockedResponse = HTTPURLResponse(url: request.url!, statusCode: statusCode, httpVersion: nil, headerFields: mockedHeaderFields )
         
         return mockedResponse
     }
@@ -281,12 +281,12 @@ class SuperMockResponseHelper: NSObject {
      - parameter request:  Represent the request (orginal not mocked) callled for obtain the data
      - parameter response: The current response, it is used to store the status code
      */
-    func recordResponseHeadersForRequest(headers:[NSObject:AnyObject], request: NSURLRequest, response: NSHTTPURLResponse) {
+    func recordResponseHeadersForRequest(_ headers:[AnyHashable: Any], request: URLRequest, response: HTTPURLResponse) {
         
-        var headersModified : [NSObject:AnyObject] = headers
+        var headersModified : [AnyHashable: Any] = headers
         headersModified["status"] = "\(response.statusCode)"
         
-        do { let data = try NSPropertyListSerialization.dataWithPropertyList(headersModified, format: NSPropertyListFormat.XMLFormat_v1_0, options: NSPropertyListWriteOptions.allZeros)
+        do { let data = try PropertyListSerialization.data(fromPropertyList: headersModified, format: PropertyListSerialization.PropertyListFormat.xml, options: PropertyListSerialization.WriteOptions.allZeros)
             recordResponseHeadersDataForRequest(data, request: request)
         } catch {
             return
@@ -294,12 +294,12 @@ class SuperMockResponseHelper: NSObject {
         
     }
     
-    private func mockedHeaderFields(url: NSURL, requestMethod: RequestMethod, mocks: Dictionary<String,AnyObject>)->[String : String]? {
+    fileprivate func mockedHeaderFields(_ url: URL, requestMethod: RequestMethod, mocks: Dictionary<String,AnyObject>)->[String : String]? {
         
-        guard let mockedHeaderFieldsURL = mockURLForRequestRestponseURL(url, requestMethod: requestMethod, mocks: mocks) where mockedHeaderFieldsURL != url else {
+        guard let mockedHeaderFieldsURL = mockURLForRequestRestponseURL(url, requestMethod: requestMethod, mocks: mocks) , mockedHeaderFieldsURL != url else {
             return nil
         }
-        guard let mockedHeaderFields = NSDictionary(contentsOfURL: mockedHeaderFieldsURL) as? [String : String] else {
+        guard let mockedHeaderFields = NSDictionary(contentsOf: mockedHeaderFieldsURL) as? [String : String] else {
             return nil
         }
         return mockedHeaderFields
@@ -308,56 +308,56 @@ class SuperMockResponseHelper: NSObject {
 
 class FileHelper {
     
-    private static let maxFileLegth = 70
+    fileprivate static let maxFileLegth = 70
 }
 
 //MARK: public methods
 extension FileHelper {
     
-    class func mockedResponseFilePath(url: NSURL)->String? {
+    class func mockedResponseFilePath(_ url: URL)->String? {
         
         return FileHelper.mockedFilePath(FileHelper.mockedResponseFileName(url))
     }
     
-    class func mockedResponseHeadersFilePath(url: NSURL)->String? {
+    class func mockedResponseHeadersFilePath(_ url: URL)->String? {
         
         return FileHelper.mockedFilePath(mockedResponseHeadersFileName(url))
     }
     
-    class func mockedResponseFileName(url: NSURL)->String {
+    class func mockedResponseFileName(_ url: URL)->String {
         
         return  FileHelper.mockedResponseFileName(url, isData: true)
     }
     
-    class func mockedResponseHeadersFileName(url: NSURL)->String {
+    class func mockedResponseHeadersFileName(_ url: URL)->String {
         
         return  FileHelper.mockedResponseFileName(url, isData: false)
     }
     
-    class func mockFileOutOfBundle()->String? {
+    class func mockFileOutOfBundle() -> String? {
         
-        let paths = NSSearchPathForDirectoriesInDomains(.DocumentDirectory, .UserDomainMask, true) as NSArray
+        let paths = NSSearchPathForDirectoriesInDomains(.documentDirectory, .userDomainMask, true) as NSArray
         let documentsDirectory = paths[0] as? String
         
-        guard let mockPath =  documentsDirectory?.stringByAppendingString("/\(SuperMockResponseHelper.sharedHelper.mocksFile).plist"),
-            let bundle = SuperMockResponseHelper.sharedHelper.bundle else {
-                return nil
+        let mockPath = (documentsDirectory)! + "/\(SuperMockResponseHelper.sharedHelper.mocksFile).plist"
+        guard let bundle = SuperMockResponseHelper.sharedHelper.bundle else {
+            return nil
         }
-        guard !NSFileManager.defaultManager().fileExistsAtPath(mockPath) else {
+        guard !FileManager.default.fileExists(atPath: mockPath) else {
             return mockPath
         }
         
         var mockDictionary = NSDictionary(dictionary:["mimes":["htm":"text/html","html":"text/html","json":"application/json"],"mocks":["DELETE":["http://exampleUrl":["data":"","resonse":""]],"POST":["http://exampleUrl":["data":"","resonse":""]],"PUT":["http://exampleUrl":["data":"","resonse":""]],"GET":["http://exampleUrl":["data":"","resonse":""]]]])
         
-        if let definitionsPath = bundle.pathForResource(SuperMockResponseHelper.sharedHelper.mocksFile, ofType: "plist"),
-            let definitions = NSMutableDictionary(contentsOfFile: definitionsPath) {
+        if let definitionsPath = bundle.path(forResource: SuperMockResponseHelper.sharedHelper.mocksFile, ofType: "plist"),
+           let definitions = NSMutableDictionary(contentsOfFile: definitionsPath) {
                 mockDictionary = definitions
         }
         
         do {
-            let data = try NSPropertyListSerialization.dataWithPropertyList(mockDictionary, format: NSPropertyListFormat.XMLFormat_v1_0, options: NSPropertyListWriteOptions.allZeros)
+            let data = try PropertyListSerialization.data(fromPropertyList: mockDictionary, format: PropertyListSerialization.PropertyListFormat.xml, options: PropertyListSerialization.WriteOptions.allZeros)
             
-            if !data.writeToFile(mockPath, atomically: true) {
+            if !((try? data.write(to: URL(fileURLWithPath: mockPath), options: [.atomic])) != nil) {
                 return nil
             }
         } catch {
@@ -371,7 +371,7 @@ extension FileHelper {
 //MARK: private methods
 extension FileHelper {
     
-    private class func fileType(mimeType: String) -> String {
+    fileprivate class func fileType(_ mimeType: String) -> String {
         
         switch (mimeType) {
         case "text/plain":
@@ -387,33 +387,29 @@ extension FileHelper {
         }
     }
     
-    private class func mockedFilePath(fileName: String)->String? {
+    fileprivate class func mockedFilePath(_ fileName: String)->String? {
         
-        let paths = NSSearchPathForDirectoriesInDomains(.DocumentDirectory, .UserDomainMask, true) as NSArray
+        let paths = NSSearchPathForDirectoriesInDomains(.documentDirectory, .userDomainMask, true) as NSArray
         let documentsDirectory = paths[0] as? String
         
-        guard let filePath = documentsDirectory?.stringByAppendingString("/\(fileName)") else {
-            return nil
-        }
-        
+        let filePath = (documentsDirectory)! + "/\(fileName)"
         print("Mocked response in: \(filePath)")
         return filePath
     }
     
-    private class func mockedResponseFileName(url: NSURL, isData:Bool)->String {
+    fileprivate class func mockedResponseFileName(_ url: URL, isData:Bool)->String {
         
-        guard var urlString = url.absoluteString.stringByAddingPercentEncodingWithAllowedCharacters(.URLHostAllowedCharacterSet()) else {
+        guard var urlString = url.absoluteString.addingPercentEncoding(withAllowedCharacters: .urlHostAllowed) else {
             fatalError("You must provide a request with a valid URL")
         }
         
-        urlString = urlString.stringByReplacingOccurrencesOfString("%2F", withString: "_")
-        
-        urlString = urlString.stringByReplacingOccurrencesOfString("http%3A", withString: "")
-        
+        urlString = urlString.replacingOccurrences(of: "%2F", with: "_")
+        urlString = urlString.replacingOccurrences(of: "http%3A", with: "")
+        urlString = urlString.replacingOccurrences(of: "http:", with: "")
         
         let urlStringLengh = urlString.characters.count
         let fromIndex = (urlStringLengh > maxFileLegth) ?maxFileLegth : urlStringLengh
-        let fileName = urlString.substringFromIndex(urlString.endIndex.advancedBy(-fromIndex))
+        let fileName = urlString.substring(from: urlString.characters.index(urlString.endIndex, offsetBy: -fromIndex))
         let fileExtension = FileHelper.fileType(SuperMockResponseHelper.sharedHelper.mimeType(url))
         
         if SuperMockResponseHelper.sharedHelper.recording {

--- a/Pod/Classes/SuperMockURLProtocol.swift
+++ b/Pod/Classes/SuperMockURLProtocol.swift
@@ -8,41 +8,41 @@
 
 import UIKit
 
-class SuperMockURLProtocol: NSURLProtocol {
+class SuperMockURLProtocol: URLProtocol {
     
-    override class func canInitWithRequest(request: NSURLRequest) -> Bool {
+    override class func canInit(with request: URLRequest) -> Bool {
         
         if request.hasMock() {
-            print("Requesting MOCK for : \(request.URL)")
+            print("Requesting MOCK for : \(request.url)")
             return true
         }
-        print("Passing Through WITHOUT MOCK : \(request.URL)")
+        print("Passing Through WITHOUT MOCK : \(request.url)")
         return false
     }
     
     
-    override class func canonicalRequestForRequest(request: NSURLRequest) -> NSURLRequest {
+    override class func canonicalRequest(for request: URLRequest) -> URLRequest {
         return request
     }
 
     override func startLoading() {
         
         let mockedRequest = SuperMockResponseHelper.sharedHelper.mockRequest(request)
-        if let mockData = SuperMockResponseHelper.sharedHelper.responseForMockRequest(mockedRequest) {
+        if let mockData = SuperMockResponseHelper.sharedHelper.responseForMockRequest(mockedRequest as URLRequest!) {
    
             //TODO: Fix up the below for use in UIWebView's.
             //      let response = NSHTTPURLResponse(URL: request.URL!, statusCode: 302, HTTPVersion: "HTTP/1.1", headerFields: ["Location":request.URL!.absoluteString])!
             //  client?.URLProtocol(self, wasRedirectedToRequest: request, redirectResponse: response)
 
-            let mimeType = SuperMockResponseHelper.sharedHelper.mimeType(mockedRequest.URL!)
-            var response = NSURLResponse(URL: mockedRequest.URL!, MIMEType: mimeType, expectedContentLength: mockData.length, textEncodingName: "utf8")
+            let mimeType = SuperMockResponseHelper.sharedHelper.mimeType(mockedRequest.url!)
+            var response = URLResponse(url: mockedRequest.url!, mimeType: mimeType, expectedContentLength: mockData.count, textEncodingName: "utf8")
             if let mockResponse = SuperMockResponseHelper.sharedHelper.mockResponse(request) {
                 response = mockResponse
             }
             
-            client?.URLProtocol(self, didReceiveResponse: response, cacheStoragePolicy: .NotAllowed)
-            client?.URLProtocol(self, didLoadData: mockData)
-            client?.URLProtocolDidFinishLoading(self)
+            client?.urlProtocol(self, didReceive: response, cacheStoragePolicy: .notAllowed)
+            client?.urlProtocol(self, didLoad: mockData)
+            client?.urlProtocolDidFinishLoading(self)
         }
     }
     
@@ -50,14 +50,14 @@ class SuperMockURLProtocol: NSURLProtocol {
     }
 }
 
-class SuperMockRecordingURLProtocol: NSURLProtocol {
+class SuperMockRecordingURLProtocol: URLProtocol {
     
     var connection : NSURLConnection?
-    var mutableData : NSMutableData?
+    var mutableData : Data?
     
-    override class func canInitWithRequest(request: NSURLRequest) -> Bool {
+    override class func canInit(with request: URLRequest) -> Bool {
         
-        if let _ = NSURLProtocol.propertyForKey("SuperMockRecordingURLProtocol", inRequest: request) {
+        if let _ = URLProtocol.property(forKey: "SuperMockRecordingURLProtocol", in: request) {
             return false
         }
         if SuperMockResponseHelper.sharedHelper.recording  {
@@ -66,22 +66,22 @@ class SuperMockRecordingURLProtocol: NSURLProtocol {
         return false
     }
     
-    override class func canonicalRequestForRequest(request: NSURLRequest) -> NSURLRequest {
+    override class func canonicalRequest(for request: URLRequest) -> URLRequest {
         return request
     }
     
-    override class func requestIsCacheEquivalent(a: NSURLRequest, toRequest b: NSURLRequest) -> Bool {
-        return super.requestIsCacheEquivalent(a, toRequest:b)
+    override class func requestIsCacheEquivalent(_ a: URLRequest, to b: URLRequest) -> Bool {
+        return super.requestIsCacheEquivalent(a, to:b)
     }
     
     override func startLoading() {
         
-        if let copyRequest = request.mutableCopy() as? NSMutableURLRequest {
+        if let copyRequest = (request as NSURLRequest).mutableCopy() as? NSMutableURLRequest {
             
-            NSURLProtocol.setProperty(request.URL!, forKey: "SuperMockRecordingURLProtocol", inRequest: copyRequest)
-            connection = NSURLConnection(request: copyRequest, delegate: self)
+            URLProtocol.setProperty(request.url!, forKey: "SuperMockRecordingURLProtocol", in: copyRequest)
+            connection = NSURLConnection(request: copyRequest as URLRequest, delegate: self)
             
-            mutableData = NSMutableData()
+            mutableData = Data()
         }
     }
     
@@ -92,25 +92,25 @@ class SuperMockRecordingURLProtocol: NSURLProtocol {
 
 extension SuperMockRecordingURLProtocol: NSURLConnectionDataDelegate {
     
-    func connection(connection: NSURLConnection, didReceiveResponse response: NSURLResponse) {
-        if let httpResponse = response as? NSHTTPURLResponse {
+    func connection(_ connection: NSURLConnection, didReceive response: URLResponse) {
+        if let httpResponse = response as? HTTPURLResponse {
             let headers = httpResponse.allHeaderFields
             SuperMockResponseHelper.sharedHelper.recordResponseHeadersForRequest(headers, request: request, response: httpResponse)
         }
-        client?.URLProtocol(self, didReceiveResponse: response, cacheStoragePolicy: NSURLCacheStoragePolicy.NotAllowed)
+        client?.urlProtocol(self, didReceive: response, cacheStoragePolicy: URLCache.StoragePolicy.notAllowed)
     }
     
-    func connection(connection: NSURLConnection, didReceiveData data: NSData) {
-        client?.URLProtocol(self, didLoadData: data)
-        mutableData?.appendData(data)
+    func connection(_ connection: NSURLConnection, didReceive data: Data) {
+        client?.urlProtocol(self, didLoad: data)
+        mutableData?.append(data)
     }
     
-    func connectionDidFinishLoading(connection: NSURLConnection) {
-        client?.URLProtocolDidFinishLoading(self)
+    func connectionDidFinishLoading(_ connection: NSURLConnection) {
+        client?.urlProtocolDidFinishLoading(self)
         SuperMockResponseHelper.sharedHelper.recordDataForRequest(mutableData, request: request)
     }
     
-    func connection(connection: NSURLConnection, didFailWithError error: NSError) {
-        client?.URLProtocol(self, didFailWithError: error)
+    func connection(_ connection: NSURLConnection, didFailWithError error: Error) {
+        client?.urlProtocol(self, didFailWithError: error)
     }
 }


### PR DESCRIPTION
## What is this:
* Convert `SuperMock` to Swift 3.

## What is done:
* Convert code base to Swift 3 using the XCode Swift converter tool
* Re-enabled unit tests + fixed broken unit tests as a result of the conversion

## What is not done:
* Re-naming functions, vars, etc. to be more Swifty (Swift 3 naming conventions: https://swift.org/documentation/api-design-guidelines/). Perhaps I'll create another Pull Request with these changes.
