### PR TITLE
added unit test coverage of the framework

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,5 @@
 language: objective-c
-osx_image: xcode7.1
+osx_image: xcode10.1
 
 install:
 - gem install xcpretty --no-rdoc --no-ri --no-document --quiet

--- a/Example/Pods/Pods.xcodeproj/xcshareddata/xcschemes/SuperMock.xcscheme
+++ b/Example/Pods/Pods.xcodeproj/xcshareddata/xcschemes/SuperMock.xcscheme
@@ -26,9 +26,19 @@
       buildConfiguration = "Debug"
       selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
       selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      codeCoverageEnabled = "YES"
       shouldUseLaunchSchemeArgsEnv = "YES">
       <Testables>
       </Testables>
+      <MacroExpansion>
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "428DD4DAFF74821A5419F25A48E2E931"
+            BuildableName = "SuperMock.framework"
+            BlueprintName = "SuperMock"
+            ReferencedContainer = "container:Pods.xcodeproj">
+         </BuildableReference>
+      </MacroExpansion>
       <AdditionalOptions>
       </AdditionalOptions>
    </TestAction>
@@ -60,6 +70,15 @@
       savedToolIdentifier = ""
       useCustomWorkingDirectory = "NO"
       debugDocumentVersioning = "YES">
+      <MacroExpansion>
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "428DD4DAFF74821A5419F25A48E2E931"
+            BuildableName = "SuperMock.framework"
+            BlueprintName = "SuperMock"
+            ReferencedContainer = "container:Pods.xcodeproj">
+         </BuildableReference>
+      </MacroExpansion>
    </ProfileAction>
    <AnalyzeAction
       buildConfiguration = "Debug">

--- a/Example/SuperMock.xcodeproj/project.pbxproj
+++ b/Example/SuperMock.xcodeproj/project.pbxproj
@@ -7,9 +7,16 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		223614E121F5922000ECBCBA /* SuperMockNSURLRequestExtensionTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 223614E021F5922000ECBCBA /* SuperMockNSURLRequestExtensionTests.swift */; };
+		223614E321F593B000ECBCBA /* SuperMockNSURLSessionConfigurationExtensionTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 223614E221F593B000ECBCBA /* SuperMockNSURLSessionConfigurationExtensionTests.swift */; };
+		2247DC5621E5C74C00B5FDCA /* SuperMockTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2247DC5521E5C74C00B5FDCA /* SuperMockTests.swift */; };
+		2247DC6221E71BBE00B5FDCA /* SuperMockResponseHelperTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2247DC6121E71BBE00B5FDCA /* SuperMockResponseHelperTests.swift */; };
+		2247DC6521EC5B0900B5FDCA /* http%3A%2F%2Fapple.com%2F.txt in Resources */ = {isa = PBXBuildFile; fileRef = 225140E41C5FDE6A0025A4A9 /* http%3A%2F%2Fapple.com%2F.txt */; };
+		2247DC6621EC5B0C00B5FDCA /* http%3A%2F%2Fapple.com%2F2FDATA.txt in Resources */ = {isa = PBXBuildFile; fileRef = 225140E51C5FDE6A0025A4A9 /* http%3A%2F%2Fapple.com%2F2FDATA.txt */; };
 		225140E71C5FDE6A0025A4A9 /* http%3A%2F%2Fapple.com%2F.txt in Resources */ = {isa = PBXBuildFile; fileRef = 225140E41C5FDE6A0025A4A9 /* http%3A%2F%2Fapple.com%2F.txt */; };
 		225140E81C5FDE6A0025A4A9 /* http%3A%2F%2Fapple.com%2F2FDATA.txt in Resources */ = {isa = PBXBuildFile; fileRef = 225140E51C5FDE6A0025A4A9 /* http%3A%2F%2Fapple.com%2F2FDATA.txt */; };
 		225140E91C5FDE6A0025A4A9 /* MocksRecorded.plist in Resources */ = {isa = PBXBuildFile; fileRef = 225140E61C5FDE6A0025A4A9 /* MocksRecorded.plist */; };
+		229F836221F8368E00B71565 /* SuperMockURLProtocolTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 229F836121F8368E00B71565 /* SuperMockURLProtocolTests.swift */; };
 		607FACD61AFB9204008FA782 /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 607FACD51AFB9204008FA782 /* AppDelegate.swift */; };
 		607FACD81AFB9204008FA782 /* ViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 607FACD71AFB9204008FA782 /* ViewController.swift */; };
 		607FACDB1AFB9204008FA782 /* Main.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 607FACD91AFB9204008FA782 /* Main.storyboard */; };
@@ -51,9 +58,15 @@
 /* Begin PBXFileReference section */
 		0E483D97D007BA7B53B0EE3A /* Pods_SuperMock_Tests.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_SuperMock_Tests.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		1720BFF65970BD47BA847A35 /* Pods-SuperMock_Tests.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-SuperMock_Tests.debug.xcconfig"; path = "Pods/Target Support Files/Pods-SuperMock_Tests/Pods-SuperMock_Tests.debug.xcconfig"; sourceTree = "<group>"; };
+		223614E021F5922000ECBCBA /* SuperMockNSURLRequestExtensionTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SuperMockNSURLRequestExtensionTests.swift; sourceTree = "<group>"; };
+		223614E221F593B000ECBCBA /* SuperMockNSURLSessionConfigurationExtensionTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SuperMockNSURLSessionConfigurationExtensionTests.swift; sourceTree = "<group>"; };
+		2247DC5521E5C74C00B5FDCA /* SuperMockTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SuperMockTests.swift; sourceTree = "<group>"; };
+		2247DC6121E71BBE00B5FDCA /* SuperMockResponseHelperTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SuperMockResponseHelperTests.swift; sourceTree = "<group>"; };
+		2247DC6721EC602B00B5FDCA /* Foundation.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = Foundation.framework; path = System/Library/Frameworks/Foundation.framework; sourceTree = SDKROOT; };
 		225140E41C5FDE6A0025A4A9 /* http%3A%2F%2Fapple.com%2F.txt */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text; path = "http%3A%2F%2Fapple.com%2F.txt"; sourceTree = "<group>"; };
 		225140E51C5FDE6A0025A4A9 /* http%3A%2F%2Fapple.com%2F2FDATA.txt */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text; path = "http%3A%2F%2Fapple.com%2F2FDATA.txt"; sourceTree = "<group>"; };
 		225140E61C5FDE6A0025A4A9 /* MocksRecorded.plist */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.xml; path = MocksRecorded.plist; sourceTree = "<group>"; };
+		229F836121F8368E00B71565 /* SuperMockURLProtocolTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SuperMockURLProtocolTests.swift; sourceTree = "<group>"; };
 		3ED9E819E95AABB83D324B07 /* LICENSE */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text; name = LICENSE; path = ../LICENSE; sourceTree = "<group>"; };
 		4DB89E890B28C1A921A71510 /* README.md */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = net.daringfireball.markdown; name = README.md; path = ../README.md; sourceTree = "<group>"; };
 		53F19A3FC83CA086C3996AA0 /* Pods-SuperMock_Example.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-SuperMock_Example.release.xcconfig"; path = "Pods/Target Support Files/Pods-SuperMock_Example/Pods-SuperMock_Example.release.xcconfig"; sourceTree = "<group>"; };
@@ -119,6 +132,14 @@
 			name = Mocks;
 			sourceTree = "<group>";
 		};
+		2247DC5421E5C72900B5FDCA /* Integrations */ = {
+			isa = PBXGroup;
+			children = (
+				607FACEB1AFB9204008FA782 /* Tests.swift */,
+			);
+			name = Integrations;
+			sourceTree = "<group>";
+		};
 		225140E31C5FDDF40025A4A9 /* Recorded */ = {
 			isa = PBXGroup;
 			children = (
@@ -178,8 +199,13 @@
 		607FACE81AFB9204008FA782 /* Tests */ = {
 			isa = PBXGroup;
 			children = (
-				607FACEB1AFB9204008FA782 /* Tests.swift */,
+				2247DC5421E5C72900B5FDCA /* Integrations */,
 				607FACE91AFB9204008FA782 /* Supporting Files */,
+				2247DC5521E5C74C00B5FDCA /* SuperMockTests.swift */,
+				2247DC6121E71BBE00B5FDCA /* SuperMockResponseHelperTests.swift */,
+				223614E021F5922000ECBCBA /* SuperMockNSURLRequestExtensionTests.swift */,
+				223614E221F593B000ECBCBA /* SuperMockNSURLSessionConfigurationExtensionTests.swift */,
+				229F836121F8368E00B71565 /* SuperMockURLProtocolTests.swift */,
 			);
 			path = Tests;
 			sourceTree = "<group>";
@@ -214,6 +240,7 @@
 		9EB096F9F940941843B149D0 /* Frameworks */ = {
 			isa = PBXGroup;
 			children = (
+				2247DC6721EC602B00B5FDCA /* Foundation.framework */,
 				8E4B020307AD9440E13068F0 /* Pods_SuperMock_Example.framework */,
 				0E483D97D007BA7B53B0EE3A /* Pods_SuperMock_Tests.framework */,
 			);
@@ -310,6 +337,8 @@
 					};
 					607FACE41AFB9204008FA782 = {
 						CreatedOnToolsVersion = 6.3.1;
+						DevelopmentTeam = W849M7QXG9;
+						ProvisioningStyle = Manual;
 						TestTargetID = 607FACCF1AFB9204008FA782;
 					};
 					630ACEC51BE7E1D200D18B4E = {
@@ -363,7 +392,9 @@
 			files = (
 				630ACEBE1BE78CB600D18B4E /* samplePOST.html in Resources */,
 				630ACEBB1BE77F1C00D18B4E /* sample.html in Resources */,
+				2247DC6621EC5B0C00B5FDCA /* http%3A%2F%2Fapple.com%2F2FDATA.txt in Resources */,
 				630ACEB71BE75ECC00D18B4E /* Mocks.plist in Resources */,
+				2247DC6521EC5B0900B5FDCA /* http%3A%2F%2Fapple.com%2F.txt in Resources */,
 				630ACED21BE7E39400D18B4E /* buttons.txt in Resources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
@@ -485,8 +516,13 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				2247DC5621E5C74C00B5FDCA /* SuperMockTests.swift in Sources */,
+				2247DC6221E71BBE00B5FDCA /* SuperMockResponseHelperTests.swift in Sources */,
+				229F836221F8368E00B71565 /* SuperMockURLProtocolTests.swift in Sources */,
+				223614E321F593B000ECBCBA /* SuperMockNSURLSessionConfigurationExtensionTests.swift in Sources */,
 				607FACEC1AFB9204008FA782 /* Tests.swift in Sources */,
 				630ACEB81BE77D5800D18B4E /* AppDelegate.swift in Sources */,
+				223614E121F5922000ECBCBA /* SuperMockNSURLRequestExtensionTests.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -642,7 +678,6 @@
 			isa = XCBuildConfiguration;
 			baseConfigurationReference = 710EF85D42E5856CA0778706 /* Pods-SuperMock_Example.debug.xcconfig */;
 			buildSettings = {
-				ALWAYS_EMBED_SWIFT_STANDARD_LIBRARIES = YES;
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				DEVELOPMENT_TEAM = W849M7QXG9;
 				INFOPLIST_FILE = SuperMock/Info.plist;
@@ -659,7 +694,6 @@
 			isa = XCBuildConfiguration;
 			baseConfigurationReference = 53F19A3FC83CA086C3996AA0 /* Pods-SuperMock_Example.release.xcconfig */;
 			buildSettings = {
-				ALWAYS_EMBED_SWIFT_STANDARD_LIBRARIES = YES;
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				DEVELOPMENT_TEAM = W849M7QXG9;
 				INFOPLIST_FILE = SuperMock/Info.plist;
@@ -677,7 +711,9 @@
 			baseConfigurationReference = 1720BFF65970BD47BA847A35 /* Pods-SuperMock_Tests.debug.xcconfig */;
 			buildSettings = {
 				ALWAYS_EMBED_SWIFT_STANDARD_LIBRARIES = YES;
-				BUNDLE_LOADER = "$(TEST_HOST)";
+				CODE_SIGN_IDENTITY = "iPhone Developer";
+				CODE_SIGN_STYLE = Manual;
+				DEVELOPMENT_TEAM = W849M7QXG9;
 				FRAMEWORK_SEARCH_PATHS = (
 					"$(SDKROOT)/Developer/Library/Frameworks",
 					"$(inherited)",
@@ -690,6 +726,7 @@
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
 				PRODUCT_BUNDLE_IDENTIFIER = "org.SuperMock.$(PRODUCT_NAME:rfc1034identifier)";
 				PRODUCT_NAME = "$(TARGET_NAME)";
+				PROVISIONING_PROFILE_SPECIFIER = "";
 				SWIFT_VERSION = 4.0;
 				TEST_HOST = "$(BUILT_PRODUCTS_DIR)/SuperMock_Example.app/SuperMock_Example";
 			};
@@ -700,7 +737,9 @@
 			baseConfigurationReference = F4C5C6D0D9AEB8477DCD2E75 /* Pods-SuperMock_Tests.release.xcconfig */;
 			buildSettings = {
 				ALWAYS_EMBED_SWIFT_STANDARD_LIBRARIES = YES;
-				BUNDLE_LOADER = "$(TEST_HOST)";
+				CODE_SIGN_IDENTITY = "iPhone Developer";
+				CODE_SIGN_STYLE = Manual;
+				DEVELOPMENT_TEAM = W849M7QXG9;
 				FRAMEWORK_SEARCH_PATHS = (
 					"$(SDKROOT)/Developer/Library/Frameworks",
 					"$(inherited)",
@@ -709,6 +748,7 @@
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
 				PRODUCT_BUNDLE_IDENTIFIER = "org.SuperMock.$(PRODUCT_NAME:rfc1034identifier)";
 				PRODUCT_NAME = "$(TARGET_NAME)";
+				PROVISIONING_PROFILE_SPECIFIER = "";
 				SWIFT_VERSION = 4.0;
 				TEST_HOST = "$(BUILT_PRODUCTS_DIR)/SuperMock_Example.app/SuperMock_Example";
 			};
@@ -717,7 +757,9 @@
 		630ACECE1BE7E1D200D18B4E /* Debug */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
+				ALWAYS_EMBED_SWIFT_STANDARD_LIBRARIES = YES;
 				DEBUG_INFORMATION_FORMAT = dwarf;
+				EMBED_ASSET_PACKS_IN_PRODUCT_BUNDLE = NO;
 				ENABLE_TESTABILITY = YES;
 				INFOPLIST_FILE = SuperMock_ExampleUITests/Info.plist;
 				IPHONEOS_DEPLOYMENT_TARGET = 9.1;
@@ -734,6 +776,8 @@
 		630ACECF1BE7E1D200D18B4E /* Release */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
+				ALWAYS_EMBED_SWIFT_STANDARD_LIBRARIES = YES;
+				EMBED_ASSET_PACKS_IN_PRODUCT_BUNDLE = NO;
 				INFOPLIST_FILE = SuperMock_ExampleUITests/Info.plist;
 				IPHONEOS_DEPLOYMENT_TARGET = 9.1;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";

--- a/Example/SuperMock.xcodeproj/xcshareddata/xcschemes/SuperMock-Example.xcscheme
+++ b/Example/SuperMock.xcodeproj/xcshareddata/xcschemes/SuperMock-Example.xcscheme
@@ -54,7 +54,18 @@
       buildConfiguration = "Debug"
       selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
       selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      codeCoverageEnabled = "YES"
+      onlyGenerateCoverageForSpecifiedTargets = "YES"
       shouldUseLaunchSchemeArgsEnv = "YES">
+      <CodeCoverageTargets>
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "428DD4DAFF74821A5419F25A48E2E931"
+            BuildableName = "SuperMock.framework"
+            BlueprintName = "SuperMock"
+            ReferencedContainer = "container:Pods/Pods.xcodeproj">
+         </BuildableReference>
+      </CodeCoverageTargets>
       <Testables>
          <TestableReference
             skipped = "NO">
@@ -65,9 +76,14 @@
                BlueprintName = "SuperMock_Tests"
                ReferencedContainer = "container:SuperMock.xcodeproj">
             </BuildableReference>
+            <SkippedTests>
+               <Test
+                  Identifier = "SuperMockHelperTests">
+               </Test>
+            </SkippedTests>
          </TestableReference>
          <TestableReference
-            skipped = "NO">
+            skipped = "YES">
             <BuildableReference
                BuildableIdentifier = "primary"
                BlueprintIdentifier = "630ACEC51BE7E1D200D18B4E"

--- a/Example/SuperMock/Mocks.plist
+++ b/Example/SuperMock/Mocks.plist
@@ -17,24 +17,51 @@
 		<dict/>
 		<key>GET</key>
 		<dict>
+			<key>http://apple.com/</key>
+			<array>
+				<dict>
+					<key>response</key>
+					<string>http%3A%2F%2Fapple.com%2F.txt</string>
+					<key>data</key>
+					<string>http%3A%2F%2Fapple.com%2F2FDATA.txt</string>
+				</dict>
+				<dict>
+					<key>response</key>
+					<string>http%3A%2F%2Fapple.com%2F.txt</string>
+					<key>data</key>
+					<string>http%3A%2F%2Fapple.com%2F2FDATA.txt</string>
+				</dict>
+				<dict>
+					<key>response</key>
+					<string>http%3A%2F%2Fapple.com%2F.txt</string>
+					<key>data</key>
+					<string>http%3A%2F%2Fapple.com%2F2FDATA.txt</string>
+				</dict>
+			</array>
 			<key>http://mike.kz/api/layout/buttons/</key>
-			<dict>
-				<key>data</key>
-				<string>buttons.txt</string>
-			</dict>
+			<array>
+				<dict>
+					<key>data</key>
+					<string>buttons.txt</string>
+				</dict>
+			</array>
 			<key>http://mike.kz/</key>
-			<dict>
-				<key>data</key>
-				<string>sample.html</string>
-			</dict>
+			<array>
+				<dict>
+					<key>data</key>
+					<string>sample.html</string>
+				</dict>
+			</array>
 		</dict>
 		<key>POST</key>
 		<dict>
 			<key>http://mike.kz/</key>
-			<dict>
-				<key>data</key>
-				<string>samplePOST.html</string>
-			</dict>
+			<array>
+				<dict>
+					<key>data</key>
+					<string>samplePOST.html</string>
+				</dict>
+			</array>
 		</dict>
 		<key>PUT</key>
 		<dict/>

--- a/Example/Tests/SuperMockNSURLRequestExtensionTests.swift
+++ b/Example/Tests/SuperMockNSURLRequestExtensionTests.swift
@@ -1,0 +1,28 @@
+//
+//  SuperMockNSURLRequestExtensionTests.swift
+//  SuperMock_Tests
+//
+//  Created by Scheggia on 21/01/2019.
+//  Copyright © 2019 CocoaPods. All rights reserved.
+//
+
+import XCTest
+@testable import SuperMock
+
+class SuperMockNSURLRequestExtensionTests: XCTestCase {
+
+    func test_hasMocks_returnTrue_whenMockExist() {
+        SuperMockResponseHelper.bundleForMocks = Bundle(for: SuperMockNSURLRequestExtensionTests.self)
+        let sut = URLRequest(url: URL(string: "http://apple.com/")!)
+        
+        XCTAssertTrue(sut.hasMock())
+    }
+    
+    func test_hasMocks_returnFalse_whenMockDoesNotExist() {
+        SuperMockResponseHelper.bundleForMocks = Bundle(for: SuperMockNSURLRequestExtensionTests.self)
+        let sut = URLRequest(url: URL(string: "http://apple.com/Daniele")!)
+        
+        XCTAssertFalse(sut.hasMock())
+    }
+
+}

--- a/Example/Tests/SuperMockNSURLSessionConfigurationExtensionTests.swift
+++ b/Example/Tests/SuperMockNSURLSessionConfigurationExtensionTests.swift
@@ -1,0 +1,31 @@
+//
+//  SuperMockNSURLSessionConfigurationExtensionTests.swift
+//  SuperMock_Tests
+//
+//  Created by Scheggia on 21/01/2019.
+//  Copyright © 2019 CocoaPods. All rights reserved.
+//
+
+import XCTest
+@testable import SuperMock
+
+class SuperMockNSURLSessionConfigurationExtensionTests: XCTestCase {
+
+    func test_addProtocols_appendRecordingProtocols_whenRecording() {
+        SuperMock.beginRecording(Bundle(for: SuperMockNSURLSessionConfigurationExtensionTests.self))
+        let sut = URLSessionConfiguration.background(withIdentifier: "")
+        sut.addProtocols()
+        
+        XCTAssertTrue(sut.protocolClasses?.first === SuperMockRecordingURLProtocol.self)
+        SuperMock.endRecording()
+    }
+    
+    func test_addProtocols_appendMockingProtocols_whenRecording() {
+        SuperMock.beginMocking(Bundle(for: SuperMockNSURLSessionConfigurationExtensionTests.self))
+        let sut = URLSessionConfiguration.background(withIdentifier: "")
+        sut.addProtocols()
+        
+        XCTAssertTrue(sut.protocolClasses?.first === SuperMockURLProtocol.self)
+        SuperMock.endMocking()
+    }
+}

--- a/Example/Tests/SuperMockResponseHelperTests.swift
+++ b/Example/Tests/SuperMockResponseHelperTests.swift
@@ -1,0 +1,249 @@
+//
+//  SuperMockResponseHelperTests.swift
+//  SuperMock_Tests
+//
+//  Created by Scheggia on 10/01/2019.
+//  Copyright © 2019 CocoaPods. All rights reserved.
+//
+
+import XCTest
+@testable import SuperMock
+
+class SuperMockResponseHelperTests: XCTestCase {
+
+    var sut = SuperMockResponseHelper.sharedHelper
+    let bundle = Bundle(for: SuperMockResponseHelperTests.self)
+    
+    override func setUp() {
+        super.setUp()
+        SuperMockResponseHelper.bundleForMocks = bundle
+    }
+    
+    func test_bundleForMocks_returnCorrectBundle() {
+        XCTAssertEqual(SuperMockResponseHelper.bundleForMocks, bundle)
+    }
+    
+    func test_bundleForMocks_triggerSetsMocks() {
+        XCTAssertEqual(sut.mocks.count, 4)
+    }
+    
+    func test_bundleForMocks_triggerSetsMimes() {
+        XCTAssertEqual(sut.mimes.count, 3)
+    }
+    
+    func test_mockRequest_returnSameRequest_whenNoMocks() {
+        let request = URLRequest(url: URL(string: "http://apple.com/Daniele")!)
+        XCTAssertEqual(sut.mockRequest(request), request)
+    }
+    
+    func test_mockRequest_returnMockedRequest_whenMockIsAvailable() {
+        let request = URLRequest(url: URL(string: "http://apple.com/")!)
+        XCTAssertNotEqual(sut.mockRequest(request), request)
+    }
+    
+    func test_mockResponse_exaustResponses_whenMockIsAvailable() {
+        guard let url = URL(string: "http://apple.com/")
+            else { return XCTFail("the url need to exist, for this test to execute") }
+        let request = URLRequest(url: url)
+        
+        var getMocks = sut.mocks["GET"] as? [String:Any]
+        var mocks = getMocks?[url.absoluteString] as? [[String:String]]
+        XCTAssertEqual(mocks?.count, 3)
+        let _ = sut.mockResponse(request)
+        getMocks = sut.mocks["GET"] as? [String:Any]
+        mocks = getMocks?[url.absoluteString] as? [[String:String]]
+        XCTAssertEqual(mocks?.count, 2)
+        let _ = sut.mockResponse(request)
+        let _ = sut.mockResponse(request)
+        let _ = sut.mockResponse(request)
+        getMocks = sut.mocks["GET"] as? [String:Any]
+        mocks = getMocks?[url.absoluteString] as? [[String:String]]
+        XCTAssertEqual(mocks?.count, 1)
+    }
+    
+    func test_mockRequest_returnMockedRequest_withSuperMockHTTPHeader() {
+        let request = URLRequest(url: URL(string: "http://apple.com/")!)
+        let newRequest = sut.mockRequest(request)
+        
+        XCTAssertEqual(newRequest.allHTTPHeaderFields?["X-SUPERMOCK-MOCKREQUEST"], "true")
+    }
+    
+    func test_responseForMockRequest_returnNil_whenItIsNotAFile() {
+        let request = URLRequest(url: URL(string: "http://apple.com/")!)
+        let data = sut.responseForMockRequest(request)
+        XCTAssertNil(data)
+    }
+    
+    func test_responseForMockRequest_returnNil_whenCannotReadFile() {
+        let request = URLRequest(url: URL(fileURLWithPath: "file.plist"))
+        let data = sut.responseForMockRequest(request)
+        XCTAssertNil(data)
+    }
+    
+    func test_responseForMockRequest_returnData() {
+        let request = URLRequest(url: URL(string: "http://apple.com/")!)
+        let newRequest = sut.mockRequest(request)
+        
+        let data = sut.responseForMockRequest(newRequest)
+        XCTAssertNotNil(data)
+        XCTAssertEqual(data?.count, 28241)
+        
+    }
+    
+    func test_mimeType_shouldReturnPlainText_whenNoUrlFound() {
+        let url = URL(string: "http://apple.com/unknown")!
+        XCTAssertEqual(sut.mimeType(url), "text/plain")
+    }
+    
+    func test_mimeType_shouldReturnType_whenUrlFound() {
+        let url = URL(string: "apple.json")!
+        XCTAssertEqual(sut.mimeType(url), "application/json")
+    }
+    
+    func test_recordDataForRequest_shouldRecordFiles() {
+        let request = URLRequest(url: URL(string: "http://apple.com/")!)
+        let mockedRequest = sut.mockRequest(request)
+        let response = sut.mockResponse(request) as? HTTPURLResponse
+        let responseData = sut.responseForMockRequest(mockedRequest)
+        SuperMock.beginRecording(bundle, mocksFile: "MocksRecording.plist")
+        
+        sut.recordDataForRequest(responseData, httpHeaders: response?.allHeaderFields, request: request)
+        
+        guard let recordedMocksFilePath = sut.mockFileOutOfBundle()
+            else { return XCTFail("The recoded filePath need to exist to locate the file") }
+        let definitions = NSDictionary(contentsOfFile: recordedMocksFilePath)
+        XCTAssertNotNil(definitions)
+        let getsMocks = definitions?.value(forKeyPath: "mocks.GET") as? [String:[[String: String]]]
+        XCTAssertEqual(getsMocks?.count, 2)
+        
+        guard let dataFile = getsMocks?["http://apple.com/"]?.last?["data"]
+            else { return XCTFail("The recoded dataPath need to be exist to locate the file") }
+        var mockUrl = URL(fileURLWithPath: recordedMocksFilePath)
+        mockUrl.deleteLastPathComponent()
+        let dataUrl = mockUrl.appendingPathComponent(dataFile)
+        let data = try? Data(contentsOf: dataUrl)
+        XCTAssertNotNil(data)
+        
+        guard let responseFile = getsMocks?["http://apple.com/"]?.last?["response"]
+            else { return XCTFail("The recoded dataPath need to be exist to locate the file") }
+        
+        let responseUrl = mockUrl.appendingPathComponent(responseFile)
+        let responseRecorded = try? Data(contentsOf: responseUrl)
+        XCTAssertNotNil(responseRecorded)
+        
+        // Clean up
+        try? FileManager.default.removeItem(atPath: recordedMocksFilePath)
+        try? FileManager.default.removeItem(at: responseUrl)
+        try? FileManager.default.removeItem(at: dataUrl)
+        SuperMock.endRecording()
+    }
+    
+    func test_recordDataForRequest_shouldNotRecord_whenMissingHeaders() {
+        let request = URLRequest(url: URL(string: "http://apple.com/")!)
+        let mockedRequest = sut.mockRequest(request)
+        let responseData = sut.responseForMockRequest(mockedRequest)
+        SuperMock.beginRecording(bundle, mocksFile: "MocksRecording.plist")
+        
+        sut.recordDataForRequest(responseData, httpHeaders: nil, request: request)
+        
+        guard let recordedMocksFilePath = sut.mockFileOutOfBundle()
+            else { return XCTFail("The recoded filePath need to exist to locate the file") }
+        let definitions = NSDictionary(contentsOfFile: recordedMocksFilePath)
+        XCTAssertNotNil(definitions)
+        let getsMocks = definitions?.value(forKeyPath: "mocks.GET") as? [String:[[String: String]]]
+        XCTAssertEqual(getsMocks?.count, 1)
+        
+        let dataFile = getsMocks?["http://apple.com/"]?.last?["data"]
+        XCTAssertNil(dataFile)
+        
+        let responseFile = getsMocks?["http://apple.com/"]?.last?["response"]
+        XCTAssertNil(responseFile)
+        
+        try? FileManager.default.removeItem(atPath: recordedMocksFilePath)
+        SuperMock.endRecording()
+    }
+    
+    func test_recordDataForRequest_shouldNotRecord_whenMissingData() {
+        let request = URLRequest(url: URL(string: "http://apple.com/")!)
+        let response = sut.mockResponse(request) as? HTTPURLResponse
+        SuperMock.beginRecording(bundle, mocksFile: "MocksRecording.plist")
+        
+        sut.recordDataForRequest(nil, httpHeaders: response?.allHeaderFields, request: request)
+        
+        guard let recordedMocksFilePath = sut.mockFileOutOfBundle()
+            else { return XCTFail("The recoded filePath need to exist to locate the file") }
+        let definitions = NSDictionary(contentsOfFile: recordedMocksFilePath)
+        XCTAssertNotNil(definitions)
+        let getsMocks = definitions?.value(forKeyPath: "mocks.GET") as? [String:[[String: String]]]
+        XCTAssertEqual(getsMocks?.count, 1)
+        
+        let dataFile = getsMocks?["http://apple.com/"]?.last?["data"]
+        XCTAssertNil(dataFile)
+        
+        let responseFile = getsMocks?["http://apple.com/"]?.last?["response"]
+        XCTAssertNil(responseFile)
+        
+        try? FileManager.default.removeItem(atPath: recordedMocksFilePath)
+        SuperMock.endRecording()
+        
+    }
+    
+    func test_recordDataForRequest_shouldRecordMultipleFiles_ForMultipleResponses() {
+        let request = URLRequest(url: URL(string: "http://apple.com/")!)
+        let mockedRequest = sut.mockRequest(request)
+        let response = sut.mockResponse(request) as? HTTPURLResponse
+        let responseData = sut.responseForMockRequest(mockedRequest)
+        SuperMock.beginRecording(bundle, mocksFile: "MocksRecording.plist")
+        
+        sut.recordDataForRequest(responseData, httpHeaders: response?.allHeaderFields, request: request)
+        sut.recordDataForRequest(responseData, httpHeaders: response?.allHeaderFields, request: request)
+        
+        guard let recordedMocksFilePath = sut.mockFileOutOfBundle()
+            else { return XCTFail("The recoded filePath need to exist to locate the file") }
+        let definitions = NSDictionary(contentsOfFile: recordedMocksFilePath)
+        XCTAssertNotNil(definitions)
+        let getsMocks = definitions?.value(forKeyPath: "mocks.GET") as? [String:[[String: String]]]
+        XCTAssertEqual(getsMocks?.count, 2)
+        
+        guard let dataFile = getsMocks?["http://apple.com/"]?.last?["data"]
+            else { return XCTFail("The recoded dataPath need to be exist to locate the file") }
+        var mockUrl = URL(fileURLWithPath: recordedMocksFilePath)
+        mockUrl.deleteLastPathComponent()
+        let dataUrl = mockUrl.appendingPathComponent(dataFile)
+        let data = try? Data(contentsOf: dataUrl)
+        XCTAssertNotNil(data)
+        
+        XCTAssertEqual(getsMocks?["http://apple.com/"]?.count, 2)
+        
+        guard let responseFile = getsMocks?["http://apple.com/"]?.last?["response"]
+            else { return XCTFail("The recoded dataPath need to be exist to locate the file") }
+        
+        let responseUrl = mockUrl.appendingPathComponent(responseFile)
+        let responseRecorded = try? Data(contentsOf: responseUrl)
+        XCTAssertNotNil(responseRecorded)
+        
+        guard let firstDataFile = getsMocks?["http://apple.com/"]?.first?["data"]
+            else { return XCTFail("The recoded dataPath need to be exist to locate the file") }
+        let firstDataUrl = mockUrl.appendingPathComponent(firstDataFile)
+        let firstData = try? Data(contentsOf: firstDataUrl)
+        XCTAssertNotNil(firstData)
+        
+        guard let firstResponseFile = getsMocks?["http://apple.com/"]?.first?["response"]
+            else { return XCTFail("The recoded dataPath need to be exist to locate the file") }
+        
+        let firstResponseUrl = mockUrl.appendingPathComponent(firstResponseFile)
+        let firstResponseRecorded = try? Data(contentsOf: firstResponseUrl)
+        XCTAssertNotNil(firstResponseRecorded)
+        
+        // Clean up
+        try? FileManager.default.removeItem(atPath: recordedMocksFilePath)
+        try? FileManager.default.removeItem(at: responseUrl)
+        try? FileManager.default.removeItem(at: dataUrl)
+        try? FileManager.default.removeItem(at: firstResponseUrl)
+        try? FileManager.default.removeItem(at: firstDataUrl)
+        SuperMock.endRecording()
+    }
+    
+    
+
+}

--- a/Example/Tests/SuperMockTests.swift
+++ b/Example/Tests/SuperMockTests.swift
@@ -1,0 +1,116 @@
+//
+//  SuperMockTests.swift
+//  SuperMock_Tests
+//
+//  Created by Scheggia on 09/01/2019.
+//  Copyright © 2019 CocoaPods. All rights reserved.
+//
+
+import XCTest
+@testable import SuperMock
+
+class SuperMockTests: XCTestCase {
+
+    let sut = SuperMock.self
+    let bundle = Bundle(for: SuperMockTests.self)
+    
+    override func tearDown() {
+        sut.endMocking()
+        MockUrlProtocol.registerClassCounter = 0
+        MockUrlProtocol.unregisterClassCounter = 0
+        super.tearDown()
+    }
+    
+    func test_beginMocking_registerProtocolsCorrectly() {
+        let session = URLSession.shared
+        let configuration = URLSessionConfiguration.default
+            
+        sut.beginMocking(bundle, urlProtocol: MockUrlProtocol.self, configuration: configuration, session: session)
+        
+        XCTAssertTrue(configuration.protocolClasses!.last === SuperMockURLProtocol.self)
+        XCTAssertEqual(MockUrlProtocol.registerClassCounter, 1)
+    }
+
+    func test_beginMocking_shouldSetTheFileName() {
+        let fileName = "MadeUpFile.name"
+        sut.beginMocking(bundle, mocksFile: fileName)
+        XCTAssertEqual(SuperMockResponseHelper.sharedHelper.mocksFile, fileName)
+    }
+    
+    func test_beginMocking_shouldSetDefaultFileName_whenNoFileNameIsSpecified() {
+        sut.beginMocking(bundle)
+        XCTAssertEqual(SuperMockResponseHelper.sharedHelper.mocksFile, "Mocks.plist")
+    }
+    
+    func test_beginMocking_setBundle() {
+        sut.beginMocking(bundle)
+        XCTAssertEqual(SuperMockResponseHelper.bundleForMocks, bundle)
+    }
+    
+    func test_beginMocking_setFlag() {
+        sut.beginMocking(bundle)
+        XCTAssertEqual(SuperMockResponseHelper.sharedHelper.mocking, true)
+    }
+    
+    func test_beginRecording_registerProtocolsCorrectly() {
+        let session = URLSession.shared
+        let configuration = URLSessionConfiguration.default
+        
+        sut.beginRecording(bundle, policy: .Record, urlProtocol: MockUrlProtocol.self, configuration: configuration, session: session)
+        
+        XCTAssertTrue(configuration.protocolClasses!.last === SuperMockRecordingURLProtocol.self)
+        XCTAssertEqual(MockUrlProtocol.registerClassCounter, 1)
+    }
+    
+    func test_beginRecording_shouldSetTheFileName() {
+        let fileName = "MadeUpFile.name"
+        sut.beginRecording(bundle, mocksFile: fileName, policy: .Record)
+        XCTAssertEqual(SuperMockResponseHelper.sharedHelper.mocksFile, fileName)
+    }
+    
+    func test_beginRecording_shouldSetDefaultFileName_whenNoFileNameIsSpecified() {
+        sut.beginRecording(bundle)
+        XCTAssertEqual(SuperMockResponseHelper.sharedHelper.mocksFile, "Mocks.plist")
+    }
+    
+    func test_beginRecording_setBundle() {
+        sut.beginRecording(bundle)
+        XCTAssertEqual(SuperMockResponseHelper.bundleForMocks, bundle)
+    }
+    
+    func test_beginRecording_setFlag() {
+        sut.beginRecording(bundle)
+        XCTAssertEqual(SuperMockResponseHelper.sharedHelper.recording, true)
+    }
+    
+    func test_beginRecording_setCorrectPolicy() {
+        sut.beginRecording(bundle, policy: .Override)
+        XCTAssertEqual(SuperMockResponseHelper.sharedHelper.recordPolicy, .Override)
+    }
+    
+    func test_endRecording_shouldUnregisterProtocol() {
+        sut.endRecording(urlProtocol: MockUrlProtocol.self)
+        XCTAssertEqual(MockUrlProtocol.unregisterClassCounter, 1)
+        XCTAssertEqual(SuperMockResponseHelper.sharedHelper.recording, false)
+    }
+    
+    func test_endmocking_shouldUnregisterProtocol() {
+        sut.endMocking(urlProtocol: MockUrlProtocol.self)
+        XCTAssertEqual(MockUrlProtocol.unregisterClassCounter, 1)
+        XCTAssertEqual(SuperMockResponseHelper.sharedHelper.mocking, false)
+    }
+}
+
+class MockUrlProtocol: URLProtocol {
+    
+    static var registerClassCounter = 0
+    override class func registerClass(_ protocolClass: AnyClass) -> Bool {
+        registerClassCounter += 1
+        return true
+    }
+    
+    static var unregisterClassCounter = 0
+    override class func unregisterClass(_ protocolClass: AnyClass) {
+        unregisterClassCounter += 1
+    }
+}

--- a/Example/Tests/SuperMockURLProtocolTests.swift
+++ b/Example/Tests/SuperMockURLProtocolTests.swift
@@ -1,0 +1,297 @@
+//
+//  SuperMockURLProtocolTests.swift
+//  SuperMock_Tests
+//
+//  Created by Scheggia on 23/01/2019.
+//  Copyright © 2019 CocoaPods. All rights reserved.
+//
+
+import XCTest
+@testable import SuperMock
+
+class SuperMockURLProtocolTests: XCTestCase {
+    var sut: SuperMockURLProtocol!
+    var client: MockURLProtocolClient!
+    var task: MockURLSessionTask!
+    
+    override func setUp() {
+        super.setUp()
+        client = MockURLProtocolClient()
+        task = MockURLSessionTask()
+        sut = SuperMockURLProtocol(task: task, cachedResponse: nil, client: client)
+        SuperMock.beginMocking(Bundle(for: SuperMockURLProtocolTests.self))
+    }
+    
+    override func tearDown() {
+        SuperMock.endMocking()
+        super.tearDown()
+    }
+    
+    func test_canInit_returnTrue_whenHasMocks() {
+        let request = URLRequest(url: URL(string: "http://apple.com/")!)
+        XCTAssertEqual(SuperMockURLProtocol.canInit(with: request), true)
+    }
+    
+    func test_canInit_returnFalse_whenHasNoMocks() {
+        let request = URLRequest(url: URL(string: "http://apple.com/Daniele")!)
+        XCTAssertEqual(SuperMockURLProtocol.canInit(with: request), false)
+        
+    }
+    
+    func test_canonicalRequest_shouldReturn_theSameRequest() {
+        let request = URLRequest(url: URL(string: "http://apple.com/Daniele")!)
+        XCTAssertEqual(SuperMockURLProtocol.canonicalRequest(for: request), request)
+    }
+    
+    func test_startLoading_shouldCallDidReceive_withCorrectResponse() {
+        sut.startLoading()
+        XCTAssertEqual(client.didReceiveCounter, 1)
+        XCTAssertNotNil(client.responseSpy)
+        XCTAssertEqual(client.responseSpy?.url, sut.request.url)
+    }
+    
+    func test_startLoading_shouldCallDidLoad_withCorrectResponse() {
+        sut.startLoading()
+        XCTAssertEqual(client.didLoadCounter, 1)
+        XCTAssertNotNil(client.dataSpy)
+    }
+    
+    func test_startLoading_shouldCallDidFinishLoading_withCorrectResponse() {
+        sut.startLoading()
+        XCTAssertEqual(client.didLoadCounter, 1)
+    }
+}
+
+class SuperMockURecordingRLProtocolTests: XCTestCase {
+    var sut: SuperMockRecordingURLProtocol!
+    var client: MockURLProtocolClient!
+    var task: MockURLSessionTask!
+    
+    override func setUp() {
+        super.setUp()
+        client = MockURLProtocolClient()
+        task = MockURLSessionTask()
+        sut = SuperMockRecordingURLProtocol(task: task, cachedResponse: nil, client: client)
+        SuperMock.beginRecording(Bundle(for: SuperMockURLProtocolTests.self))
+        sut.dataTask = URLSessionDataTask()
+    }
+    
+    override func tearDown() {
+        SuperMock.endMocking()
+        super.tearDown()
+    }
+    
+    func test_canInit_returnTrue_whenRecording() {
+        let request = URLRequest(url: URL(string: "http://apple.com/")!)
+        XCTAssertEqual(SuperMockRecordingURLProtocol.canInit(with: request), true)
+    }
+    
+    func test_canInit_returnFalse_whenHasMockKeyInHeader() {
+        let request = NSMutableURLRequest(url: URL(string: "http://apple.com/Daniele")!)
+        URLProtocol.setProperty(request.url!, forKey: "SuperMockRecordingURLProtocol", in: request)
+        XCTAssertEqual(SuperMockRecordingURLProtocol.canInit(with: request as URLRequest), false)
+    }
+    
+    func test_canInit_returnFalse_whenIsNotrecording() {
+        SuperMock.endRecording()
+        let request = URLRequest(url: URL(string: "http://apple.com/Daniele")!)
+        XCTAssertEqual(SuperMockRecordingURLProtocol.canInit(with: request), false)
+    }
+    
+    func test_canonicalRequest_shouldReturn_theSameRequest() {
+        let request = URLRequest(url: URL(string: "http://apple.com/Daniele")!)
+        XCTAssertEqual(SuperMockRecordingURLProtocol.canonicalRequest(for: request), request)
+    }
+    
+    func test_startLoading_shouldStartNewDataTask_withCopyrequest() {
+        sut.startLoading()
+        XCTAssertNotNil(sut.dataTask)
+        XCTAssertNotEqual(sut.dataTask?.currentRequest, task.currentRequest)
+        XCTAssertNotEqual(sut.dataTask, task)
+        XCTAssertEqual(sut.dataTask?.currentRequest?.url, task.currentRequest?.url)
+    }
+    
+    func test_stopLoading_shouldNilDataTask() {
+        sut.startLoading()
+        sut.stopLoading()
+        XCTAssertNil(sut.dataTask)
+    }
+    
+    func test_stopLoading_shouldNilResponse() {
+        sut.startLoading()
+        sut.response = URLResponse(url: URL(string: "http://aple.com/")!, mimeType: nil, expectedContentLength: 100, textEncodingName: nil)
+        sut.stopLoading()
+        XCTAssertNil(sut.response)
+    }
+    
+    func test_stopLoading_shouldEmptyMutableData() {
+        sut.startLoading()
+        let mutableData = NSMutableData(base64Encoded: "someRandomString", options: NSData.Base64DecodingOptions.ignoreUnknownCharacters)!
+        sut.mutableData = mutableData
+        sut.stopLoading()
+        XCTAssertNotNil(sut.mutableData)
+        XCTAssertEqual(sut.mutableData.length, 0)
+        XCTAssertNotEqual(sut.mutableData, mutableData)
+    }
+    
+    func test_didReceive_shouldCallDidLoadOnClient() {
+        let session = URLSession(configuration: URLSessionConfiguration.default)
+        let data = "someDAta".data(using: .utf8)
+        sut.startLoading()
+        
+        sut.urlSession(session, dataTask: sut.dataTask!, didReceive: data!)
+        XCTAssertEqual(client.didLoadCounter, 1)
+    }
+    
+    func test_didReceive_shouldAppendData() {
+        let session = URLSession(configuration: URLSessionConfiguration.default)
+        let data = "someDAta".data(using: .utf8)
+        sut.startLoading()
+        
+        sut.urlSession(session, dataTask: sut.dataTask!, didReceive: data!)
+        XCTAssertEqual(sut.mutableData.length, data?.count)
+    }
+    
+    func test_didReceiveResponse_shouldCallClient() {
+        let session = URLSession(configuration: URLSessionConfiguration.default)
+        let response = URLResponse(url: URL(string: "http://aple.com/")!, mimeType: nil, expectedContentLength: 100, textEncodingName: nil)
+        
+        sut.urlSession(session, dataTask: sut.dataTask!, didReceive: response) { _ in }
+        
+        XCTAssertEqual(client.didReceiveCounter, 1)
+    }
+    
+    func test_didReceiveResponse_shoulInitMutableData() {
+        sut.mutableData = NSMutableData(base64Encoded: "someData".data(using: .utf8)!, options: NSData.Base64DecodingOptions.ignoreUnknownCharacters)!
+        let session = URLSession(configuration: URLSessionConfiguration.default)
+        let response = URLResponse(url: URL(string: "http://aple.com/")!, mimeType: nil, expectedContentLength: 100, textEncodingName: nil)
+        
+        sut.urlSession(session, dataTask: sut.dataTask!, didReceive: response) { _ in }
+        
+        XCTAssertEqual(sut.mutableData.length, 0)
+    }
+    
+    func test_didReceiveResponse_shoulCallCompletionHandler() {
+        let session = URLSession(configuration: URLSessionConfiguration.default)
+        let response = URLResponse(url: URL(string: "http://aple.com/")!, mimeType: nil, expectedContentLength: 100, textEncodingName: nil)
+        
+        var completionCounter = 0
+        sut.urlSession(session, dataTask: sut.dataTask!, didReceive: response) { _ in completionCounter += 1 }
+        
+        XCTAssertEqual(completionCounter, 1)
+    }
+    
+    func test_didComplete_shouldCallFail_onError() {
+        let session = URLSession(configuration: URLSessionConfiguration.default)
+        let error = NSError(domain: "Random error", code: 500, userInfo: nil)
+        
+        sut.urlSession(session, task: task, didCompleteWithError: error)
+        XCTAssertEqual(client.failCounter, 1)
+        XCTAssertEqual(client.didfinishingLoadingCounter, 0)
+        
+    }
+    
+    func test_didComplet_shouldCallFinish_OnSuccess() {
+        let session = URLSession(configuration: URLSessionConfiguration.default)
+        
+        sut.urlSession(session, task: task, didCompleteWithError: nil)
+        XCTAssertEqual(client.failCounter, 0)
+        XCTAssertEqual(client.didfinishingLoadingCounter, 1)
+        
+    }
+    
+    func test_didComplet_shouldRecorDataForRequest_OnSuccess() {
+        let session = URLSession(configuration: URLSessionConfiguration.default)
+        sut.mutableData = NSMutableData(base64Encoded: "someData".data(using: .utf8)!, options: NSData.Base64DecodingOptions.ignoreUnknownCharacters)!
+        let request = URLRequest(url: URL(string: "http://apple.com/")!)
+        SuperMockRecordingURLProtocol.canInit(with: request)
+        
+        let bundle = Bundle(for: SuperMockURLProtocolTests.self)
+        
+        SuperMock.beginRecording(bundle, mocksFile: "MocksRecording.plist")
+        
+        sut.urlSession(session, task: task, didCompleteWithError: nil)
+        
+        guard let recordedMocksFilePath = SuperMockResponseHelper.sharedHelper.mockFileOutOfBundle()
+            else { return XCTFail("The recoded filePath need to exist to locate the file") }
+        let definitions = NSDictionary(contentsOfFile: recordedMocksFilePath)
+        XCTAssertNotNil(definitions)
+        let getsMocks = definitions?.value(forKeyPath: "mocks.GET") as? [String:[[String: String]]]
+        XCTAssertEqual(getsMocks?.count, 2)
+        
+        guard let dataFile = getsMocks?["http://apple.com/"]?.last?["data"]
+            else { return XCTFail("The recoded dataPath need to be exist to locate the file") }
+        var mockUrl = URL(fileURLWithPath: recordedMocksFilePath)
+        mockUrl.deleteLastPathComponent()
+        let dataUrl = mockUrl.appendingPathComponent(dataFile)
+        let data = try? Data(contentsOf: dataUrl)
+        XCTAssertNotNil(data)
+        XCTAssertEqual(data, sut.mutableData as Data)
+        
+        guard let responseFile = getsMocks?["http://apple.com/"]?.last?["response"]
+            else { return XCTFail("The recoded dataPath need to be exist to locate the file") }
+        
+        let responseUrl = mockUrl.appendingPathComponent(responseFile)
+        let responseRecorded = try? Data(contentsOf: responseUrl)
+        XCTAssertNotNil(responseRecorded)
+        
+        // Clean up
+        try? FileManager.default.removeItem(atPath: recordedMocksFilePath)
+        try? FileManager.default.removeItem(at: responseUrl)
+        try? FileManager.default.removeItem(at: dataUrl)
+        SuperMock.endRecording()
+        
+        XCTAssertEqual(client.didfinishingLoadingCounter, 1)
+    }
+}
+
+class MockURLSessionTask: URLSessionTask {
+    var requestSpy = URLRequest(url: URL(string: "http://apple.com/")!)
+    override var currentRequest: URLRequest? {
+        return requestSpy
+    }
+    
+    var _response = HTTPURLResponse(url: URL(string: "http://aple.com/")!, statusCode: 200, httpVersion: nil, headerFields: [:])
+    override var response: URLResponse? {
+        return _response
+    }
+}
+
+class MockURLProtocolClient:NSObject, URLProtocolClient {
+    
+    var responseSpy: URLResponse?
+    var cachePolicySpy: URLCache.StoragePolicy?
+    var didReceiveCounter = 0
+    func urlProtocol(_ protocol: URLProtocol, didReceive response: URLResponse, cacheStoragePolicy policy: URLCache.StoragePolicy) {
+        responseSpy = response
+        cachePolicySpy = policy
+        didReceiveCounter += 1
+    }
+    
+    var didLoadCounter = 0
+    var dataSpy: Data?
+    func urlProtocol(_ protocol: URLProtocol, didLoad data: Data) {
+        dataSpy = data
+        didLoadCounter += 1
+    }
+    
+    
+    func urlProtocol(_ protocol: URLProtocol, wasRedirectedTo request: URLRequest, redirectResponse: URLResponse) {}
+    
+    func urlProtocol(_ protocol: URLProtocol, cachedResponseIsValid cachedResponse: CachedURLResponse) {}
+    
+    var didfinishingLoadingCounter = 0
+    func urlProtocolDidFinishLoading(_ protocol: URLProtocol) {
+        didfinishingLoadingCounter += 1
+    }
+    var failCounter = 0
+    func urlProtocol(_ protocol: URLProtocol, didFailWithError error: Error) {
+        failCounter += 1
+    }
+    
+    func urlProtocol(_ protocol: URLProtocol, didReceive challenge: URLAuthenticationChallenge) { }
+    
+    
+    func urlProtocol(_ protocol: URLProtocol, didCancel challenge: URLAuthenticationChallenge) { }
+    
+}

--- a/Example/Tests/Tests.swift
+++ b/Example/Tests/Tests.swift
@@ -83,23 +83,4 @@ class Tests: XCTestCase {
         
         XCTAssertNotNil(mockRequest.url?.isFileURL, "fileURL mocked request should be returned when a mock is available.")
     }
-    
-    func testRecordDataAsMock() {
-        
-        let url = URL(string: "http://mike.kz/Daniele")!
-        let realRequest = URLRequest(url: url)
-        
-        let responseString = "Something to put into the response field"
-        
-        let responseHelper = SuperMockResponseHelper.sharedHelper
-        let expectedData = responseString.data(using: .utf8)
-        
-        responseHelper.recordDataForRequest(expectedData, request: realRequest)
-        
-        let mockRequest = responseHelper.mockRequest(realRequest)
-        let returnedData = responseHelper.responseForMockRequest(mockRequest)
-        
-        XCTAssertEqual(expectedData, returnedData, "Expected data not received for mock.")
-        
-    }
 }


### PR DESCRIPTION
- solved the issue of consuming the request when multiple responses for the same url request
- improved representation in DATA.txt recorded files for recorded headers, making easy to change it. Kept compatibility with past data saved files
- coverage at 92.9%, can be improved, but it is at good level